### PR TITLE
CI: split test_libraries into per-package parallel jobs (Phase 1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,10 @@ jobs:
           path: |
             ./packages/lf-api-js/types
 
-  test_libraries:
+  # Per-package test jobs all fan out from build_libraries in parallel so
+  # a failure in one package does not block test runs for the others.
+
+  test_lf_js_utils:
     runs-on: ubuntu-latest
     needs: [build_libraries]
     steps:
@@ -151,16 +154,77 @@ jobs:
           list-tests: 'failed'
           fail-on-error: 'false'
 
+  test_lf_api_client_core_cloud:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
+
       - name: pnpm test lf-api-client-core on cloud
-        id: test-cloud
         env:
           ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
           ACCESS_KEY_JSON: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY_JSON }}
           SERVICE_PRINCIPAL_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
         run: pnpm --filter @laserfiche/lf-api-client-core run test:Cloud
 
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: Client Core (cloud) Jest Test Results
+          path: ./packages/lf-api-client-core-js/*.xml
+          reporter: jest-junit
+          only-summary: 'false'
+          list-tests: 'failed'
+          fail-on-error: 'false'
+
+  test_lf_api_client_core_self_hosted:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
+
       - name: pnpm test lf-api-client-core on self-hosted
-        if: always() && (steps.test-cloud.outcome == 'success' || steps.test-cloud.outcome == 'failure')
         env:
           REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
           APISERVER_USERNAME: ${{ secrets.APISERVER_USERNAME }}
@@ -172,12 +236,38 @@ jobs:
         uses: dorny/test-reporter@v2
         if: success() || failure() # run this step even if previous step failed
         with:
-          name: Client Core Jest Test Results
+          name: Client Core (self-hosted) Jest Test Results
           path: ./packages/lf-api-client-core-js/*.xml
           reporter: jest-junit
           only-summary: 'false'
           list-tests: 'failed'
           fail-on-error: 'false'
+
+  test_v1_cloud:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
 
       - name: pnpm test @laserfiche/lf-repository-api-client run all cloud tests
         env:
@@ -187,6 +277,43 @@ jobs:
           AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
         run: pnpm --filter @laserfiche/lf-repository-api-client run test:all
+
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: Api Client v1 (cloud) Jest Test Results
+          path: ./packages/lf-repository-api-client-v1/*.xml
+          reporter: jest-junit
+          only-summary: 'false'
+          list-tests: 'failed'
+          fail-on-error: 'false'
+
+  test_v1_self_hosted:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
 
       - name: pnpm test @laserfiche/lf-repository-api-client run all self-hosted tests
         env:
@@ -204,15 +331,40 @@ jobs:
         uses: dorny/test-reporter@v2
         if: success() || failure() # run this step even if previous step failed
         with:
-          name: Api Client v1 Jest Test Results
+          name: Api Client v1 (self-hosted) Jest Test Results
           path: ./packages/lf-repository-api-client-v1/*.xml
           reporter: jest-junit
           only-summary: 'false'
           list-tests: 'failed'
           fail-on-error: 'false'
 
+  test_v2_node:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
+
       - name: pnpm test lf-repository-api-client-v2 on cloud (node environment)
-        id: test-cloud-node
         env:
           ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
           SERVICE_PRINCIPAL_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
@@ -221,8 +373,44 @@ jobs:
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
         run: pnpm --filter @laserfiche/lf-repository-api-client-v2 run test:node
 
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: Api Client v2 (node) Jest Test Results
+          path: ./packages/lf-repository-api-client-v2/*.xml
+          reporter: jest-junit
+          only-summary: 'false'
+          list-tests: 'failed'
+          fail-on-error: 'false'
+
+  test_v2_browser:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
+
       - name: pnpm test lf-repository-api-client-v2 on cloud (browser environment)
-        id: test-cloud-browser
         env:
           ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
           SERVICE_PRINCIPAL_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
@@ -231,16 +419,42 @@ jobs:
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
         run: pnpm --filter @laserfiche/lf-repository-api-client-v2 run test:browser
 
-      - name: Test report
+      - name: Test Report
         uses: dorny/test-reporter@v2
         if: success() || failure() # run this step even if previous step failed
         with:
-          name: Api Client v2 Jest Test Results
+          name: Api Client v2 (browser) Jest Test Results
           path: ./packages/lf-repository-api-client-v2/*.xml
           reporter: jest-junit
           only-summary: 'false'
           list-tests: 'failed'
           fail-on-error: 'false'
+
+  test_lf_api_js:
+    runs-on: ubuntu-latest
+    needs: [build_libraries]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Echo build number
+        run: echo ${{github.run_id}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install pnpm
+        run: npm install pnpm@latest-9 -g
+
+      - name: PNPM install
+        run: pnpm install
+
+      - name: PNPM run build
+        run: pnpm run build
 
       - name: pnpm test @laserfiche/lf-api-js run all tests
         run: pnpm --filter @laserfiche/lf-api-js run test
@@ -255,10 +469,19 @@ jobs:
           only-summary: 'false'
           list-tests: 'failed'
           fail-on-error: 'false'
-          
+
   build_documentation:
     runs-on: ubuntu-latest
-    needs: [build_libraries, test_libraries]
+    needs:
+      - build_libraries
+      - test_lf_js_utils
+      - test_lf_api_client_core_cloud
+      - test_lf_api_client_core_self_hosted
+      - test_v1_cloud
+      - test_v1_self_hosted
+      - test_v2_node
+      - test_v2_browser
+      - test_lf_api_js
     steps:
       - uses: actions/checkout@v4
 
@@ -313,7 +536,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm_publish
     if: ${{ github.run_attempt != 1 }}
-    needs: [build_libraries, test_libraries, build_documentation]
+    needs:
+      - build_libraries
+      - test_lf_js_utils
+      - test_lf_api_client_core_cloud
+      - test_lf_api_client_core_self_hosted
+      - test_v1_cloud
+      - test_v1_self_hosted
+      - test_v2_node
+      - test_v2_browser
+      - test_lf_api_js
+      - build_documentation
     steps:
       - uses: actions/checkout@v4
 
@@ -435,7 +668,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm_publish
     if: ${{ github.run_attempt != 1 }}
-    needs: [build_libraries, test_libraries, build_documentation]
+    needs:
+      - build_libraries
+      - test_lf_js_utils
+      - test_lf_api_client_core_cloud
+      - test_lf_api_client_core_self_hosted
+      - test_v1_cloud
+      - test_v1_self_hosted
+      - test_v2_node
+      - test_v2_browser
+      - test_lf_api_js
+      - build_documentation
     steps:
       - uses: actions/checkout@v4
 
@@ -525,7 +768,17 @@ jobs:
   publish_documentation:
     runs-on: ubuntu-latest
     if: ${{ github.run_attempt != 1 }}
-    needs: [build_libraries, test_libraries, build_documentation]
+    needs:
+      - build_libraries
+      - test_lf_js_utils
+      - test_lf_api_client_core_cloud
+      - test_lf_api_client_core_self_hosted
+      - test_v1_cloud
+      - test_v1_self_hosted
+      - test_v2_node
+      - test_v2_browser
+      - test_lf_api_js
+      - build_documentation
     environment: github-pages
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Work item: #657996

Phase 1 of the CI decoupling: replaces the monolithic `test_libraries` job with eight per-package jobs that fan out from `build_libraries` in parallel. A failure in one package no longer blocks any other package's tests.

New jobs: `test_lf_js_utils`, `test_lf_api_client_core_cloud`, `test_lf_api_client_core_self_hosted`, `test_v1_cloud`, `test_v1_self_hosted`, `test_v2_node`, `test_v2_browser`, `test_lf_api_js`.

Phase 2 (`continue-on-error: true` on self-hosted jobs + branch-protection update) lands in a follow-up.