### PR TITLE
build: exclude vitest.config*.ts from production tsc output

### DIFF
--- a/packages/lf-api-js/tsconfig.json
+++ b/packages/lf-api-js/tsconfig.json
@@ -99,5 +99,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["test/", "dist/", "jest.*.js"]
+  "exclude": ["test/", "dist/", "jest.*.js", "vitest.config*.ts"]
 }

--- a/packages/lf-repository-api-client-v1/tsconfig.json
+++ b/packages/lf-repository-api-client-v1/tsconfig.json
@@ -97,5 +97,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["test/", "dist/", "jest.*.js"]
+  "exclude": ["test/", "dist/", "jest.*.js", "vitest.config*.ts"]
 }


### PR DESCRIPTION
## Summary

Fast-follow on #44. After the jest → vitest migration, `packages/lf-api-js/tsconfig.json` and `packages/lf-repository-api-client-v1/tsconfig.json` were leaking the new `vitest.config*.ts` files into their published `dist/` artifacts because their `exclude` lists covered `test/`, `dist/`, and `jest.*.js` but not the vitest counterparts.

`packages/lf-repository-api-client-v2/tsconfig.json` already excluded `vitest.config*.ts`. This PR brings the V1 client and the lf-api-js root package into line.

## Changes

- `packages/lf-api-js/tsconfig.json` — add `"vitest.config*.ts"` to `exclude`.
- `packages/lf-repository-api-client-v1/tsconfig.json` — same.

Two-line patch.

## Verification

Before fix: V1 emitted `dist/vitest.config.{js,d.ts,js.map}` + `.browser` variants; lf-api-js emitted `dist/vitest.config.{js,d.ts,js.map}`. After clean rebuild on this branch: both `dist/` directories are vitest-config-free, and `pnpm test` still passes (vitest reads its config independently of tsc).

## Why it matters

Without this, the npm artifact includes a test-only TypeScript config that imports the dev dependency `vitest/config`. Consumers installing the package would get extra files in their `node_modules` and a phantom dev-only import path — not a runtime break (the file isn't in the entry tree) but unwanted shipping noise.

This must land before publishing 1.1.0 from main so the released artifact is clean.

## Test plan

- [x] Local clean rebuild produces no `vitest.config*` files in `dist/` for either package.
- [x] `pnpm --filter @laserfiche/lf-api-js run test` passes.
- [ ] CI green on this branch.