### PR TITLE
Regen JS client for Field Definition Admin endpoints (PRD 6.3.A)

### DIFF
--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8,7 +8,10 @@
   },
   "servers": [
     {
-      "url": "https://api.laserfiche.com/repository"
+      "url": "http://localhost:11211/repository"
+    },
+    {
+      "url": "https://localhost:11211/repository"
     }
   ],
   "paths": {
@@ -564,6 +567,216 @@
             }
           }
         }
+      },
+      "patch": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Partial-update merge semantics. null = leave unchanged; \"\" = clear a string property.\n- FieldType cannot be changed via this endpoint \u2014 use the dedicated ChangeFieldType endpoint.\n- ListValues cannot be changed via this endpoint \u2014 use the dedicated ListValues endpoints.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateFieldDefinition",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition to update.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The properties to change. Only non-null properties are applied; null leaves the property unchanged. Empty string clears a string property.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFieldDefinitionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Deletes the specified field definition. Behavior when the field is referenced by templates or assigned to entries mirrors the underlying repository server response \u2014 if rejected by the server, the response surfaces the server error.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteFieldDefinition",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition to delete.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the field definition."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v2/Repositories/{repositoryId}/FieldDefinitions": {
@@ -699,6 +912,579 @@
           },
           "404": {
             "description": "Not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Creates a new metadata field definition with the supplied core attributes, flags, and (optionally) initial list values for list-backed fields.\n- Names must be unique within the repository; duplicate-name failures return 400.\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateFieldDefinition",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The field definition to create. Name and FieldType are required.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFieldDefinitionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Returns the field's configured list-item values in repository-configured order.\n- Applies only to list-backed fields; non-list fields return an empty array.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldListValues",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the list values for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListValuesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Replaces the field's full list-item set wholesale. No partial add/remove endpoints are exposed.\n- Duplicates and empty-string values are rejected with 400.\n- Required OAuth scope: repository.Write",
+        "operationId": "ReplaceFieldListValues",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The new list of values. Order is preserved. Empty array clears the list.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplaceListValuesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the list values for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListValuesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ContainingTemplates": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Lists template definitions that include the specified field. Useful before performing destructive operations on the field.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldContainingTemplates",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 6
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the templates that contain the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TemplateDefinition"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AssignedEntryCount": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Useful for impact analysis before performing destructive operations such as type changes or deletion.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldAssignedEntryCount",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the count of entries assigned to the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignedEntryCountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2093,7 +2879,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4017,7 +4803,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4127,7 +4913,7 @@
         "tags": [
           "Entries"
         ],
-        "summary": "- Updates a document entry from previously uploaded parts. The parts are assembled server-side into a single file that is then applied to the existing document.\n- The uploadId is obtained from the CreateMultipartUploadUrls response. The partETags are the ETag values returned by S3 when uploading each file chunk to the pre-signed upload URLs, and should be provided in the order of their associated upload URLs.\n- Use this endpoint when the file exceeds the upload size or time limits of the synchronous PATCH /Document endpoint.\n- The assembled file is applied as either the electronic document or image pages, following the same rules as the synchronous PATCH /Document:\n  - If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if `importAsElectronicDocument=true`, the file replaces the existing electronic document. For supported edoc formats, `pdfOptions.generatePages` additionally produces server-rendered image pages, and `pdfOptions.generateText` triggers text extraction from the document (or OCR when the source is image-based).\n  - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.\n- If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.\n- Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.\n- `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.\n- Required OAuth scope: repository.Write",
+        "summary": "- Updates a document entry from previously uploaded parts. The parts are assembled server-side into a single file that is then applied to the existing document.\n- The uploadId is obtained from the CreateMultipartUploadUrls response. The partETags are the ETag values returned by S3 when uploading each file chunk to the pre-signed upload URLs, and should be provided in the order of their associated upload URLs.\n- Use this endpoint when the file exceeds the upload size or time limits of the synchronous PATCH /Document endpoint.\n- The assembled file is applied as either the electronic document or image pages, following the same rules as the synchronous PATCH /Document:\n  - If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if `importAsElectronicDocument=true`, the file replaces the existing electronic document. For supported edoc formats, `pdfOptions.generatePages` additionally produces server-rendered image pages, and `pdfOptions.generateText` triggers text extraction from the document (or OCR when the source is image-based).\n  - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.\n- If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.\n- Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.\n- `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.\n- Required OAuth scope: repository.Write",
         "operationId": "UpdateDocumentUploadedParts",
         "parameters": [
           {
@@ -4557,7 +5343,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4701,7 +5487,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -9468,6 +10254,26 @@
             "type": "string",
             "description": "The custom format pattern for fields that are configured to use a custom format.",
             "nullable": true
+          },
+          "isIndexed": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the field is indexed for searching."
+          },
+          "isIndexedForReporting": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the field is indexed for reporting."
+          },
+          "warnIfBlank": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the user should be warned when leaving the field blank."
+          },
+          "hideListValues": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the field's list values should be hidden in the UI.\nApplies only to list-backed fields."
+          },
+          "autoExtract": {
+            "type": "boolean",
+            "description": "A boolean indicating whether values for this field can be automatically extracted by AI/OCR services."
           }
         }
       },
@@ -9652,6 +10458,321 @@
             "items": {
               "$ref": "#/components/schemas/FieldDefinition"
             }
+          }
+        }
+      },
+      "CreateFieldDefinitionRequest": {
+        "type": "object",
+        "description": "Request body for creating a new field definition. Name and FieldType are required;\nall other properties are optional and fall back to repository defaults when omitted.",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "fieldType"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the field. Required. Must be unique within the repository."
+          },
+          "fieldType": {
+            "description": "The type of the field. Required. Cannot be changed via UpdateFieldDefinition;\nuse the ChangeFieldType endpoint to convert between types.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldType"
+              }
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the field.",
+            "nullable": true
+          },
+          "length": {
+            "type": "integer",
+            "description": "The maximum length of the field for variable-length data types.",
+            "format": "int32",
+            "nullable": true
+          },
+          "defaultValue": {
+            "type": "string",
+            "description": "The default value applied to entries assigned to a template containing this field.",
+            "nullable": true
+          },
+          "format": {
+            "description": "The display format for the field. Defaults to None when omitted.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldFormat"
+              }
+            ]
+          },
+          "formatPattern": {
+            "type": "string",
+            "description": "The custom format pattern. Only meaningful when Format is set to a value that supports custom patterns.",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "description": "The currency for numeric fields when Format is Currency.",
+            "nullable": true
+          },
+          "constraint": {
+            "type": "string",
+            "description": "A validation constraint expression for values stored in this field.",
+            "nullable": true
+          },
+          "constraintError": {
+            "type": "string",
+            "description": "The error message returned when the constraint is violated.",
+            "nullable": true
+          },
+          "isMultiValue": {
+            "type": "boolean",
+            "description": "Whether the field supports multiple values.",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required on entries assigned to a template containing it.",
+            "nullable": true
+          },
+          "isIndexed": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for searching.",
+            "nullable": true
+          },
+          "isIndexedForReporting": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for reporting.",
+            "nullable": true
+          },
+          "warnIfBlank": {
+            "type": "boolean",
+            "description": "Whether the user should be warned when leaving the field blank.",
+            "nullable": true
+          },
+          "hideListValues": {
+            "type": "boolean",
+            "description": "Whether list values should be hidden in the UI. Applies only to list-backed fields.",
+            "nullable": true
+          },
+          "autoExtract": {
+            "type": "boolean",
+            "description": "Whether values for this field can be automatically extracted by AI/OCR services.",
+            "nullable": true
+          },
+          "listValues": {
+            "type": "array",
+            "description": "Initial list values to populate. Applies only when FieldType is List.\nOrder is preserved. Use the dedicated ListValues endpoints to manage list values after creation.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateFieldDefinitionRequest": {
+        "type": "object",
+        "description": "Request body for partial-update of an existing field definition. Every property is optional.\nnull = leave the property unchanged.\nEmpty string (\"\") on a string property = clear the value.\nFieldType cannot be changed via this endpoint \u2014 use the ChangeFieldType endpoint.\nListValues cannot be changed via this endpoint \u2014 use the dedicated ListValues endpoints.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new name of the field. Must be unique within the repository.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the field.",
+            "nullable": true
+          },
+          "length": {
+            "type": "integer",
+            "description": "The maximum length of the field for variable-length data types.",
+            "format": "int32",
+            "nullable": true
+          },
+          "defaultValue": {
+            "type": "string",
+            "description": "The default value applied to entries assigned to a template containing this field.",
+            "nullable": true
+          },
+          "format": {
+            "description": "The display format for the field.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldFormat"
+              }
+            ]
+          },
+          "formatPattern": {
+            "type": "string",
+            "description": "The custom format pattern.",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "description": "The currency for numeric fields when Format is Currency.",
+            "nullable": true
+          },
+          "constraint": {
+            "type": "string",
+            "description": "A validation constraint expression for values stored in this field.",
+            "nullable": true
+          },
+          "constraintError": {
+            "type": "string",
+            "description": "The error message returned when the constraint is violated.",
+            "nullable": true
+          },
+          "isMultiValue": {
+            "type": "boolean",
+            "description": "Whether the field supports multiple values.",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required on entries assigned to a template containing it.",
+            "nullable": true
+          },
+          "isIndexed": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for searching.",
+            "nullable": true
+          },
+          "isIndexedForReporting": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for reporting.",
+            "nullable": true
+          },
+          "warnIfBlank": {
+            "type": "boolean",
+            "description": "Whether the user should be warned when leaving the field blank.",
+            "nullable": true
+          },
+          "hideListValues": {
+            "type": "boolean",
+            "description": "Whether list values should be hidden in the UI. Applies only to list-backed fields.",
+            "nullable": true
+          },
+          "autoExtract": {
+            "type": "boolean",
+            "description": "Whether values for this field can be automatically extracted by AI/OCR services.",
+            "nullable": true
+          }
+        }
+      },
+      "ListValuesResponse": {
+        "type": "object",
+        "description": "Response containing the list values of a field definition, in the order configured on the server.",
+        "additionalProperties": false,
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The ordered list of list-item values.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ReplaceListValuesRequest": {
+        "type": "object",
+        "description": "Request body for replacing the list values of a list-backed field definition.\nThe provided values replace the field's full list-item set wholesale, preserving the supplied order.\nAn empty array clears the list.",
+        "additionalProperties": false,
+        "required": [
+          "values"
+        ],
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The ordered list of list-item values to apply. Duplicates and empty strings are rejected with 400.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TemplateDefinition": {
+        "type": "object",
+        "description": "Represents a template definition.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The ID of the template definition.",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the template definition.",
+            "nullable": true
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The localized name of the template definition.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the template definition.",
+            "nullable": true
+          },
+          "color": {
+            "description": "The color assigned to the template definition.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LFColor"
+              }
+            ]
+          },
+          "fieldCount": {
+            "type": "integer",
+            "description": "The number of field definitions assigned to the template definition.",
+            "format": "int32"
+          }
+        }
+      },
+      "LFColor": {
+        "type": "object",
+        "description": "Represents an RGB color value with alpha channel.",
+        "additionalProperties": false,
+        "properties": {
+          "a": {
+            "type": "integer",
+            "description": "The alpha channel component, from 0-255.",
+            "format": "byte"
+          },
+          "r": {
+            "type": "integer",
+            "description": "The red channel component, from 0-255.",
+            "format": "byte"
+          },
+          "g": {
+            "type": "integer",
+            "description": "The green channel component, from 0-255.",
+            "format": "byte"
+          },
+          "b": {
+            "type": "integer",
+            "description": "The blue channel component from 0-255.",
+            "format": "byte"
+          }
+        }
+      },
+      "AssignedEntryCountResponse": {
+        "type": "object",
+        "description": "The number of entries that have a value assigned for a given field definition.",
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "The count of entries currently using this field.",
+            "format": "int32"
           }
         }
       },
@@ -10616,12 +11737,12 @@
               },
               "lockedBy": {
                 "type": "string",
-                "description": "The account name of the persistent lock holder. Null if the document is not locked.",
+                "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the persistent lock holder. Null if the document is not locked.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.\nTo test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally.",
                 "nullable": true
               },
               "isLockedByAnotherUser": {
                 "type": "boolean",
-                "description": "A boolean indicating if the document is locked by a user other than the authenticated user.\nFalse if the document is not locked or is locked by the authenticated user.\nOnly populated on single-entry GET, not in listing results."
+                "description": "A boolean indicating if the document is locked by a user other than the authenticated user.\nFalse if the document is not locked or is locked by the authenticated user.\nComputed from a stable principal identifier comparison, not from LockedBy.\nOnly populated on single-entry GET, not in listing results."
               },
               "currentVersion": {
                 "type": "integer",
@@ -10630,12 +11751,12 @@
               },
               "checkedOutBy": {
                 "type": "string",
-                "description": "The account name of the user who checked out the document. Null if the document is not checked out.",
+                "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the user who checked out the document. Null if the document is not checked out.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.\nTo test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally.",
                 "nullable": true
               },
               "isCheckedOutByAnotherUser": {
                 "type": "boolean",
-                "description": "A boolean indicating if the document is checked out by a user other than the authenticated user.\nFalse if the document is not checked out or is checked out by the authenticated user.\nOnly populated on single-entry GET, not in listing results."
+                "description": "A boolean indicating if the document is checked out by a user other than the authenticated user.\nFalse if the document is not checked out or is checked out by the authenticated user.\nComputed from a stable principal identifier comparison, not from CheckedOutBy.\nOnly populated on single-entry GET, not in listing results."
               }
             }
           }
@@ -11585,7 +12706,7 @@
           },
           "owner": {
             "type": "string",
-            "description": "The account name of the lock owner (e.g., \"DOMAIN\\user\").",
+            "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the lock owner.\nSame value reported as lockedBy on Document for the same lock.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.",
             "nullable": true
           },
           "comment": {
@@ -12353,74 +13474,6 @@
             "items": {
               "$ref": "#/components/schemas/TemplateDefinition"
             }
-          }
-        }
-      },
-      "TemplateDefinition": {
-        "type": "object",
-        "description": "Represents a template definition.",
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The ID of the template definition.",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the template definition.",
-            "nullable": true
-          },
-          "displayName": {
-            "type": "string",
-            "description": "The localized name of the template definition.",
-            "nullable": true
-          },
-          "description": {
-            "type": "string",
-            "description": "The description of the template definition.",
-            "nullable": true
-          },
-          "color": {
-            "description": "The color assigned to the template definition.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/LFColor"
-              }
-            ]
-          },
-          "fieldCount": {
-            "type": "integer",
-            "description": "The number of field definitions assigned to the template definition.",
-            "format": "int32"
-          }
-        }
-      },
-      "LFColor": {
-        "type": "object",
-        "description": "Represents an RGB color value with alpha channel.",
-        "additionalProperties": false,
-        "properties": {
-          "a": {
-            "type": "integer",
-            "description": "The alpha channel component, from 0-255.",
-            "format": "byte"
-          },
-          "r": {
-            "type": "integer",
-            "description": "The red channel component, from 0-255.",
-            "format": "byte"
-          },
-          "g": {
-            "type": "integer",
-            "description": "The green channel component, from 0-255.",
-            "format": "byte"
-          },
-          "b": {
-            "type": "integer",
-            "description": "The blue channel component from 0-255.",
-            "format": "byte"
           }
         }
       },

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8,10 +8,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:11211/repository"
-    },
-    {
-      "url": "https://localhost:11211/repository"
+      "url": "https://api.laserfiche.com/repository"
     }
   ],
   "paths": {

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -1516,6 +1516,235 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Properties": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the extended properties for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldPropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.\n- Empty set and empty remove is a no-op and returns the current bag.\n- Returns the full property bag after the change.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateFieldProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFieldPropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the extended properties for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldPropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/LinkDefinitions": {
       "get": {
         "tags": [
@@ -10569,6 +10798,14 @@
             "items": {
               "type": "string"
             }
+          },
+          "properties": {
+            "type": "object",
+            "description": "Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.\nUse the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.\nFor list fields, this is where the admin UI stores sort order, add-blank, add-Other,\ndisplay-as-dropdown, and similar UI-display options.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -10773,6 +11010,44 @@
             "type": "integer",
             "description": "The count of entries currently using this field.",
             "format": "int32"
+          }
+        }
+      },
+      "FieldPropertiesResponse": {
+        "type": "object",
+        "description": "Response body for the extended-properties bag on a field definition. The bag is opaque:\nkeys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field\nsort order, add-blank, add-Other, display-as), and values are strings the UI interprets.",
+        "additionalProperties": false,
+        "properties": {
+          "properties": {
+            "type": "object",
+            "description": "The full set of extended properties currently set on the field.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateFieldPropertiesRequest": {
+        "type": "object",
+        "description": "Request body for partially updating the extended-properties bag on a field definition.\nEntries in Set are written (creating or overwriting). Entries in Remove\nare deleted. Properties not mentioned in either are left unchanged.",
+        "additionalProperties": false,
+        "properties": {
+          "set": {
+            "type": "object",
+            "description": "Properties to set. Keys absent here are not modified.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "remove": {
+            "type": "array",
+            "description": "Property keys to remove. Keys not currently set are ignored.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -59,7 +59,7 @@ export class AttributesClient implements IAttributesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -373,7 +373,7 @@ export class AuditReasonsClient implements IAuditReasonsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -506,6 +506,27 @@ export interface IFieldDefinitionsClient {
     getFieldDefinition(args: { repositoryId: string, fieldId: number, culture?: string | null | undefined, select?: string | null | undefined }): Promise<FieldDefinition>;
 
     /**
+     * - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.
+    - FieldType cannot be changed via this endpoint — use the dedicated ChangeFieldType endpoint.
+    - ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition to update.
+     * @param args.request The properties to change. Only non-null properties are applied; null leaves the property unchanged. Empty string clears a string property.
+     * @returns Successfully updated the field definition.
+     */
+    updateFieldDefinition(args: { repositoryId: string, fieldId: number, request: UpdateFieldDefinitionRequest }): Promise<FieldDefinition>;
+
+    /**
+     * - Deletes the specified field definition. Behavior when the field is referenced by templates or assigned to entries mirrors the underlying repository server response — if rejected by the server, the response surfaces the server error.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition to delete.
+     * @returns Successfully deleted the field definition.
+     */
+    deleteFieldDefinition(args: { repositoryId: string, fieldId: number }): Promise<void>;
+
+    /**
      * - Returns a paged listing of field definitions available in the specified repository.
     - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
     - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
@@ -521,6 +542,60 @@ export interface IFieldDefinitionsClient {
      * @returns Successfully returned field definitions.
      */
     listFieldDefinitions(args: { repositoryId: string, prefer?: string | null | undefined, culture?: string | null | undefined, select?: string | null | undefined, orderby?: string | null | undefined, top?: number | undefined, skip?: number | undefined, count?: boolean | undefined }): Promise<FieldDefinitionCollectionResponse>;
+
+    /**
+     * - Creates a new metadata field definition with the supplied core attributes, flags, and (optionally) initial list values for list-backed fields.
+    - Names must be unique within the repository; duplicate-name failures return 400.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.request The field definition to create. Name and FieldType are required.
+     * @returns Successfully created the field definition.
+     */
+    createFieldDefinition(args: { repositoryId: string, request: CreateFieldDefinitionRequest }): Promise<FieldDefinition>;
+
+    /**
+     * - Returns the field's configured list-item values in repository-configured order.
+    - Applies only to list-backed fields; non-list fields return an empty array.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the list values for the field definition.
+     */
+    getFieldListValues(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<ListValuesResponse>;
+
+    /**
+     * - Replaces the field's full list-item set wholesale. No partial add/remove endpoints are exposed.
+    - Duplicates and empty-string values are rejected with 400.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.request The new list of values. Order is preserved. Empty array clears the list.
+     * @returns Successfully replaced the list values for the field definition.
+     */
+    replaceFieldListValues(args: { repositoryId: string, fieldId: number, request: ReplaceListValuesRequest }): Promise<ListValuesResponse>;
+
+    /**
+     * - Lists template definitions that include the specified field. Useful before performing destructive operations on the field.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the templates that contain the field definition.
+     */
+    getFieldContainingTemplates(args: { repositoryId: string, fieldId: number, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<TemplateDefinition[]>;
+
+    /**
+     * - Useful for impact analysis before performing destructive operations such as type changes or deletion.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the count of entries assigned to the field definition.
+     */
+    getFieldAssignedEntryCount(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<AssignedEntryCountResponse>;
 }
 
 export class FieldDefinitionsClient implements IFieldDefinitionsClient {
@@ -530,7 +605,7 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -705,6 +780,189 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
     }
 
     /**
+     * - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.
+    - FieldType cannot be changed via this endpoint — use the dedicated ChangeFieldType endpoint.
+    - ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition to update.
+     * @param args.request The properties to change. Only non-null properties are applied; null leaves the property unchanged. Empty string clears a string property.
+     * @returns Successfully updated the field definition.
+     */
+    updateFieldDefinition(args: { repositoryId: string, fieldId: number, request: UpdateFieldDefinitionRequest }): Promise<FieldDefinition> {
+        let { repositoryId, fieldId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateFieldDefinition(_response);
+        });
+    }
+
+    protected processUpdateFieldDefinition(response: Response): Promise<FieldDefinition> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldDefinition.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldDefinition>(null as any);
+    }
+
+    /**
+     * - Deletes the specified field definition. Behavior when the field is referenced by templates or assigned to entries mirrors the underlying repository server response — if rejected by the server, the response surfaces the server error.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition to delete.
+     * @returns Successfully deleted the field definition.
+     */
+    deleteFieldDefinition(args: { repositoryId: string, fieldId: number }): Promise<void> {
+        let { repositoryId, fieldId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteFieldDefinition(_response);
+        });
+    }
+
+    protected processDeleteFieldDefinition(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * - Returns a paged listing of field definitions available in the specified repository.
     - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
     - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
@@ -819,6 +1077,482 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
         }
         return Promise.resolve<FieldDefinitionCollectionResponse>(null as any);
     }
+
+    /**
+     * - Creates a new metadata field definition with the supplied core attributes, flags, and (optionally) initial list values for list-backed fields.
+    - Names must be unique within the repository; duplicate-name failures return 400.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.request The field definition to create. Name and FieldType are required.
+     * @returns Successfully created the field definition.
+     */
+    createFieldDefinition(args: { repositoryId: string, request: CreateFieldDefinitionRequest }): Promise<FieldDefinition> {
+        let { repositoryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processCreateFieldDefinition(_response);
+        });
+    }
+
+    protected processCreateFieldDefinition(response: Response): Promise<FieldDefinition> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldDefinition.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldDefinition>(null as any);
+    }
+
+    /**
+     * - Returns the field's configured list-item values in repository-configured order.
+    - Applies only to list-backed fields; non-list fields return an empty array.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the list values for the field definition.
+     */
+    getFieldListValues(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<ListValuesResponse> {
+        let { repositoryId, fieldId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetFieldListValues(_response);
+        });
+    }
+
+    protected processGetFieldListValues(response: Response): Promise<ListValuesResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ListValuesResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ListValuesResponse>(null as any);
+    }
+
+    /**
+     * - Replaces the field's full list-item set wholesale. No partial add/remove endpoints are exposed.
+    - Duplicates and empty-string values are rejected with 400.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.request The new list of values. Order is preserved. Empty array clears the list.
+     * @returns Successfully replaced the list values for the field definition.
+     */
+    replaceFieldListValues(args: { repositoryId: string, fieldId: number, request: ReplaceListValuesRequest }): Promise<ListValuesResponse> {
+        let { repositoryId, fieldId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processReplaceFieldListValues(_response);
+        });
+    }
+
+    protected processReplaceFieldListValues(response: Response): Promise<ListValuesResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = ListValuesResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<ListValuesResponse>(null as any);
+    }
+
+    /**
+     * - Lists template definitions that include the specified field. Useful before performing destructive operations on the field.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the templates that contain the field definition.
+     */
+    getFieldContainingTemplates(args: { repositoryId: string, fieldId: number, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<TemplateDefinition[]> {
+        let { repositoryId, fieldId, select, orderby, count } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ContainingTemplates?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        if (orderby !== undefined && orderby !== null)
+            url_ += "$orderby=" + encodeURIComponent("" + orderby) + "&";
+        if (count === null)
+            throw new Error("The parameter 'count' cannot be null.");
+        else if (count !== undefined)
+            url_ += "$count=" + encodeURIComponent("" + count) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetFieldContainingTemplates(_response);
+        });
+    }
+
+    protected processGetFieldContainingTemplates(response: Response): Promise<TemplateDefinition[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(TemplateDefinition.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TemplateDefinition[]>(null as any);
+    }
+
+    /**
+     * - Useful for impact analysis before performing destructive operations such as type changes or deletion.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the count of entries assigned to the field definition.
+     */
+    getFieldAssignedEntryCount(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<AssignedEntryCountResponse> {
+        let { repositoryId, fieldId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AssignedEntryCount?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetFieldAssignedEntryCount(_response);
+        });
+    }
+
+    protected processGetFieldAssignedEntryCount(response: Response): Promise<AssignedEntryCountResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AssignedEntryCountResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AssignedEntryCountResponse>(null as any);
+    }
 }
 
 export interface ILinkDefinitionsClient {
@@ -859,7 +1593,7 @@ export class LinkDefinitionsClient implements ILinkDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -1258,7 +1992,7 @@ export interface IEntriesClient {
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @param args.file (optional) Optional. The file to import. If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if importAsElectronicDocument=true, it is stored as the electronic document. Otherwise (image extension with importAsElectronicDocument=false), it is imported as image pages. A zero-byte file creates an empty document with no electronic document and no pages.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Document was created successfully. Returns created entry.
      */
     importEntry(args: { repositoryId: string, entryId: number, culture?: string | null | undefined, file?: FileParameter | undefined, request?: ImportEntryRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry>;
@@ -1442,7 +2176,7 @@ export interface IEntriesClient {
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @param args.file (optional) Optional. The electronic document or image file to apply to the existing document. If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if importAsElectronicDocument=true, it replaces the existing electronic document. Otherwise (image extension with importAsElectronicDocument=false), it is imported as image pages. A zero-byte file is rejected with 400; use DELETE /Document/Edoc to remove the electronic document.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Successfully updated the document. Returned the updated entry.
      */
     updateDocument(args: { repositoryId: string, entryId: number, culture?: string | null | undefined, file?: FileParameter | undefined, request?: UpdateDocumentRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry>;
@@ -1456,7 +2190,7 @@ export interface IEntriesClient {
       - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.
     - If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.
     - Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.
-    - `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.
+    - `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.
     - Required OAuth scope: repository.Write
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The requested document ID.
@@ -1500,7 +2234,7 @@ export interface IEntriesClient {
      * @param args.pageNumber (optional) Optional 1-based page number. If omitted, pages are appended to the end. If provided, pages are inserted at that position.
      * @param args.generateText (optional) If true, triggers server-side text generation (OCR) for image pages. Default is false.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Successfully created pages in the specified document. Returned the updated entry.
      */
     createPages(args: { repositoryId: string, entryId: number, pageNumber?: number | null | undefined, generateText?: boolean | undefined, request?: PagesContentRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry>;
@@ -1514,7 +2248,7 @@ export interface IEntriesClient {
      * @param args.entryId The requested document ID.
      * @param args.generateText (optional) If true, triggers server-side text generation (OCR) after creating pages. Default is false.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Successfully replaced all pages in the specified document. Returned the updated entry.
      */
     replacePages(args: { repositoryId: string, entryId: number, generateText?: boolean | undefined, request?: PagesContentRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry>;
@@ -1749,7 +2483,7 @@ export class EntriesClient implements IEntriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -2839,7 +3573,7 @@ export class EntriesClient implements IEntriesClient {
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @param args.file (optional) Optional. The file to import. If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if importAsElectronicDocument=true, it is stored as the electronic document. Otherwise (image extension with importAsElectronicDocument=false), it is imported as image pages. A zero-byte file creates an empty document with no electronic document and no pages.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Document was created successfully. Returns created entry.
      */
     importEntry(args: { repositoryId: string, entryId: number, culture?: string | null | undefined, file?: FileParameter | undefined, request?: ImportEntryRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry> {
@@ -4230,7 +4964,7 @@ export class EntriesClient implements IEntriesClient {
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @param args.file (optional) Optional. The electronic document or image file to apply to the existing document. If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if importAsElectronicDocument=true, it replaces the existing electronic document. Otherwise (image extension with importAsElectronicDocument=false), it is imported as image pages. A zero-byte file is rejected with 400; use DELETE /Document/Edoc to remove the electronic document.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Successfully updated the document. Returned the updated entry.
      */
     updateDocument(args: { repositoryId: string, entryId: number, culture?: string | null | undefined, file?: FileParameter | undefined, request?: UpdateDocumentRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry> {
@@ -4350,7 +5084,7 @@ export class EntriesClient implements IEntriesClient {
       - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.
     - If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.
     - Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.
-    - `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.
+    - `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.
     - Required OAuth scope: repository.Write
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The requested document ID.
@@ -4671,7 +5405,7 @@ export class EntriesClient implements IEntriesClient {
      * @param args.pageNumber (optional) Optional 1-based page number. If omitted, pages are appended to the end. If provided, pages are inserted at that position.
      * @param args.generateText (optional) If true, triggers server-side text generation (OCR) for image pages. Default is false.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Successfully created pages in the specified document. Returned the updated entry.
      */
     createPages(args: { repositoryId: string, entryId: number, pageNumber?: number | null | undefined, generateText?: boolean | undefined, request?: PagesContentRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry> {
@@ -4786,7 +5520,7 @@ export class EntriesClient implements IEntriesClient {
      * @param args.entryId The requested document ID.
      * @param args.generateText (optional) If true, triggers server-side text generation (OCR) after creating pages. Default is false.
      * @param args.request (optional) 
-     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+     * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Successfully replaced all pages in the specified document. Returned the updated entry.
      */
     replacePages(args: { repositoryId: string, entryId: number, generateText?: boolean | undefined, request?: PagesContentRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry> {
@@ -6789,7 +7523,7 @@ export class RepositoriesClient implements IRepositoriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -6950,7 +7684,7 @@ export class SearchesClient implements ISearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -7524,7 +8258,7 @@ export class SimpleSearchesClient implements ISimpleSearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -7704,7 +8438,7 @@ export class TagDefinitionsClient implements ITagDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -8041,7 +8775,7 @@ export class TasksClient implements ITasksClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -8408,7 +9142,7 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -9468,6 +10202,17 @@ export class FieldDefinition implements IFieldDefinition {
     currency?: string | undefined;
     /** The custom format pattern for fields that are configured to use a custom format. */
     formatPattern?: string | undefined;
+    /** A boolean indicating whether the field is indexed for searching. */
+    isIndexed?: boolean;
+    /** A boolean indicating whether the field is indexed for reporting. */
+    isIndexedForReporting?: boolean;
+    /** A boolean indicating whether the user should be warned when leaving the field blank. */
+    warnIfBlank?: boolean;
+    /** A boolean indicating whether the field's list values should be hidden in the UI.
+Applies only to list-backed fields. */
+    hideListValues?: boolean;
+    /** A boolean indicating whether values for this field can be automatically extracted by AI/OCR services. */
+    autoExtract?: boolean;
 
     
     
@@ -9501,6 +10246,11 @@ export class FieldDefinition implements IFieldDefinition {
             this.format = _data["format"];
             this.currency = _data["currency"];
             this.formatPattern = _data["formatPattern"];
+            this.isIndexed = _data["isIndexed"];
+            this.isIndexedForReporting = _data["isIndexedForReporting"];
+            this.warnIfBlank = _data["warnIfBlank"];
+            this.hideListValues = _data["hideListValues"];
+            this.autoExtract = _data["autoExtract"];
         }
     }
 
@@ -9532,6 +10282,11 @@ export class FieldDefinition implements IFieldDefinition {
         data["format"] = this.format;
         data["currency"] = this.currency;
         data["formatPattern"] = this.formatPattern;
+        data["isIndexed"] = this.isIndexed;
+        data["isIndexedForReporting"] = this.isIndexedForReporting;
+        data["warnIfBlank"] = this.warnIfBlank;
+        data["hideListValues"] = this.hideListValues;
+        data["autoExtract"] = this.autoExtract;
         return data;
     }
 }
@@ -9568,6 +10323,17 @@ export interface IFieldDefinition {
     currency?: string | undefined;
     /** The custom format pattern for fields that are configured to use a custom format. */
     formatPattern?: string | undefined;
+    /** A boolean indicating whether the field is indexed for searching. */
+    isIndexed?: boolean;
+    /** A boolean indicating whether the field is indexed for reporting. */
+    isIndexedForReporting?: boolean;
+    /** A boolean indicating whether the user should be warned when leaving the field blank. */
+    warnIfBlank?: boolean;
+    /** A boolean indicating whether the field's list values should be hidden in the UI.
+Applies only to list-backed fields. */
+    hideListValues?: boolean;
+    /** A boolean indicating whether values for this field can be automatically extracted by AI/OCR services. */
+    autoExtract?: boolean;
 }
 
 /** Enumeration of Laserfiche template field types. */
@@ -9659,6 +10425,571 @@ export interface IFieldDefinitionCollectionResponse {
     odataCount?: number | undefined;
     /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
+}
+
+/** Request body for creating a new field definition. Name and FieldType are required; all other properties are optional and fall back to repository defaults when omitted. */
+export class CreateFieldDefinitionRequest implements ICreateFieldDefinitionRequest {
+    /** The name of the field. Required. Must be unique within the repository. */
+    name!: string;
+    /** The type of the field. Required. Cannot be changed via UpdateFieldDefinition;
+use the ChangeFieldType endpoint to convert between types. */
+    fieldType!: FieldType;
+    /** The description of the field. */
+    description?: string | undefined;
+    /** The maximum length of the field for variable-length data types. */
+    length?: number | undefined;
+    /** The default value applied to entries assigned to a template containing this field. */
+    defaultValue?: string | undefined;
+    /** The display format for the field. Defaults to None when omitted. */
+    format?: FieldFormat | undefined;
+    /** The custom format pattern. Only meaningful when Format is set to a value that supports custom patterns. */
+    formatPattern?: string | undefined;
+    /** The currency for numeric fields when Format is Currency. */
+    currency?: string | undefined;
+    /** A validation constraint expression for values stored in this field. */
+    constraint?: string | undefined;
+    /** The error message returned when the constraint is violated. */
+    constraintError?: string | undefined;
+    /** Whether the field supports multiple values. */
+    isMultiValue?: boolean | undefined;
+    /** Whether the field is required on entries assigned to a template containing it. */
+    isRequired?: boolean | undefined;
+    /** Whether the field is indexed for searching. */
+    isIndexed?: boolean | undefined;
+    /** Whether the field is indexed for reporting. */
+    isIndexedForReporting?: boolean | undefined;
+    /** Whether the user should be warned when leaving the field blank. */
+    warnIfBlank?: boolean | undefined;
+    /** Whether list values should be hidden in the UI. Applies only to list-backed fields. */
+    hideListValues?: boolean | undefined;
+    /** Whether values for this field can be automatically extracted by AI/OCR services. */
+    autoExtract?: boolean | undefined;
+    /** Initial list values to populate. Applies only when FieldType is List.
+Order is preserved. Use the dedicated ListValues endpoints to manage list values after creation. */
+    listValues?: string[] | undefined;
+
+    
+    
+    constructor(data?: ICreateFieldDefinitionRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.name = _data["name"];
+            this.fieldType = _data["fieldType"];
+            this.description = _data["description"];
+            this.length = _data["length"];
+            this.defaultValue = _data["defaultValue"];
+            this.format = _data["format"];
+            this.formatPattern = _data["formatPattern"];
+            this.currency = _data["currency"];
+            this.constraint = _data["constraint"];
+            this.constraintError = _data["constraintError"];
+            this.isMultiValue = _data["isMultiValue"];
+            this.isRequired = _data["isRequired"];
+            this.isIndexed = _data["isIndexed"];
+            this.isIndexedForReporting = _data["isIndexedForReporting"];
+            this.warnIfBlank = _data["warnIfBlank"];
+            this.hideListValues = _data["hideListValues"];
+            this.autoExtract = _data["autoExtract"];
+            if (Array.isArray(_data["listValues"])) {
+                this.listValues = [] as any;
+                for (let item of _data["listValues"])
+                    this.listValues!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): CreateFieldDefinitionRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateFieldDefinitionRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["name"] = this.name;
+        data["fieldType"] = this.fieldType;
+        data["description"] = this.description;
+        data["length"] = this.length;
+        data["defaultValue"] = this.defaultValue;
+        data["format"] = this.format;
+        data["formatPattern"] = this.formatPattern;
+        data["currency"] = this.currency;
+        data["constraint"] = this.constraint;
+        data["constraintError"] = this.constraintError;
+        data["isMultiValue"] = this.isMultiValue;
+        data["isRequired"] = this.isRequired;
+        data["isIndexed"] = this.isIndexed;
+        data["isIndexedForReporting"] = this.isIndexedForReporting;
+        data["warnIfBlank"] = this.warnIfBlank;
+        data["hideListValues"] = this.hideListValues;
+        data["autoExtract"] = this.autoExtract;
+        if (Array.isArray(this.listValues)) {
+            data["listValues"] = [];
+            for (let item of this.listValues)
+                data["listValues"].push(item);
+        }
+        return data;
+    }
+}
+
+/** Request body for creating a new field definition. Name and FieldType are required; all other properties are optional and fall back to repository defaults when omitted. */
+export interface ICreateFieldDefinitionRequest {
+    /** The name of the field. Required. Must be unique within the repository. */
+    name: string;
+    /** The type of the field. Required. Cannot be changed via UpdateFieldDefinition;
+use the ChangeFieldType endpoint to convert between types. */
+    fieldType: FieldType;
+    /** The description of the field. */
+    description?: string | undefined;
+    /** The maximum length of the field for variable-length data types. */
+    length?: number | undefined;
+    /** The default value applied to entries assigned to a template containing this field. */
+    defaultValue?: string | undefined;
+    /** The display format for the field. Defaults to None when omitted. */
+    format?: FieldFormat | undefined;
+    /** The custom format pattern. Only meaningful when Format is set to a value that supports custom patterns. */
+    formatPattern?: string | undefined;
+    /** The currency for numeric fields when Format is Currency. */
+    currency?: string | undefined;
+    /** A validation constraint expression for values stored in this field. */
+    constraint?: string | undefined;
+    /** The error message returned when the constraint is violated. */
+    constraintError?: string | undefined;
+    /** Whether the field supports multiple values. */
+    isMultiValue?: boolean | undefined;
+    /** Whether the field is required on entries assigned to a template containing it. */
+    isRequired?: boolean | undefined;
+    /** Whether the field is indexed for searching. */
+    isIndexed?: boolean | undefined;
+    /** Whether the field is indexed for reporting. */
+    isIndexedForReporting?: boolean | undefined;
+    /** Whether the user should be warned when leaving the field blank. */
+    warnIfBlank?: boolean | undefined;
+    /** Whether list values should be hidden in the UI. Applies only to list-backed fields. */
+    hideListValues?: boolean | undefined;
+    /** Whether values for this field can be automatically extracted by AI/OCR services. */
+    autoExtract?: boolean | undefined;
+    /** Initial list values to populate. Applies only when FieldType is List.
+Order is preserved. Use the dedicated ListValues endpoints to manage list values after creation. */
+    listValues?: string[] | undefined;
+}
+
+/** Request body for partial-update of an existing field definition. Every property is optional. null = leave the property unchanged. Empty string ("") on a string property = clear the value. FieldType cannot be changed via this endpoint — use the ChangeFieldType endpoint. ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints. */
+export class UpdateFieldDefinitionRequest implements IUpdateFieldDefinitionRequest {
+    /** The new name of the field. Must be unique within the repository. */
+    name?: string | undefined;
+    /** The description of the field. */
+    description?: string | undefined;
+    /** The maximum length of the field for variable-length data types. */
+    length?: number | undefined;
+    /** The default value applied to entries assigned to a template containing this field. */
+    defaultValue?: string | undefined;
+    /** The display format for the field. */
+    format?: FieldFormat | undefined;
+    /** The custom format pattern. */
+    formatPattern?: string | undefined;
+    /** The currency for numeric fields when Format is Currency. */
+    currency?: string | undefined;
+    /** A validation constraint expression for values stored in this field. */
+    constraint?: string | undefined;
+    /** The error message returned when the constraint is violated. */
+    constraintError?: string | undefined;
+    /** Whether the field supports multiple values. */
+    isMultiValue?: boolean | undefined;
+    /** Whether the field is required on entries assigned to a template containing it. */
+    isRequired?: boolean | undefined;
+    /** Whether the field is indexed for searching. */
+    isIndexed?: boolean | undefined;
+    /** Whether the field is indexed for reporting. */
+    isIndexedForReporting?: boolean | undefined;
+    /** Whether the user should be warned when leaving the field blank. */
+    warnIfBlank?: boolean | undefined;
+    /** Whether list values should be hidden in the UI. Applies only to list-backed fields. */
+    hideListValues?: boolean | undefined;
+    /** Whether values for this field can be automatically extracted by AI/OCR services. */
+    autoExtract?: boolean | undefined;
+
+    
+    
+    constructor(data?: IUpdateFieldDefinitionRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.name = _data["name"];
+            this.description = _data["description"];
+            this.length = _data["length"];
+            this.defaultValue = _data["defaultValue"];
+            this.format = _data["format"];
+            this.formatPattern = _data["formatPattern"];
+            this.currency = _data["currency"];
+            this.constraint = _data["constraint"];
+            this.constraintError = _data["constraintError"];
+            this.isMultiValue = _data["isMultiValue"];
+            this.isRequired = _data["isRequired"];
+            this.isIndexed = _data["isIndexed"];
+            this.isIndexedForReporting = _data["isIndexedForReporting"];
+            this.warnIfBlank = _data["warnIfBlank"];
+            this.hideListValues = _data["hideListValues"];
+            this.autoExtract = _data["autoExtract"];
+        }
+    }
+
+    static fromJS(data: any): UpdateFieldDefinitionRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateFieldDefinitionRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["name"] = this.name;
+        data["description"] = this.description;
+        data["length"] = this.length;
+        data["defaultValue"] = this.defaultValue;
+        data["format"] = this.format;
+        data["formatPattern"] = this.formatPattern;
+        data["currency"] = this.currency;
+        data["constraint"] = this.constraint;
+        data["constraintError"] = this.constraintError;
+        data["isMultiValue"] = this.isMultiValue;
+        data["isRequired"] = this.isRequired;
+        data["isIndexed"] = this.isIndexed;
+        data["isIndexedForReporting"] = this.isIndexedForReporting;
+        data["warnIfBlank"] = this.warnIfBlank;
+        data["hideListValues"] = this.hideListValues;
+        data["autoExtract"] = this.autoExtract;
+        return data;
+    }
+}
+
+/** Request body for partial-update of an existing field definition. Every property is optional. null = leave the property unchanged. Empty string ("") on a string property = clear the value. FieldType cannot be changed via this endpoint — use the ChangeFieldType endpoint. ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints. */
+export interface IUpdateFieldDefinitionRequest {
+    /** The new name of the field. Must be unique within the repository. */
+    name?: string | undefined;
+    /** The description of the field. */
+    description?: string | undefined;
+    /** The maximum length of the field for variable-length data types. */
+    length?: number | undefined;
+    /** The default value applied to entries assigned to a template containing this field. */
+    defaultValue?: string | undefined;
+    /** The display format for the field. */
+    format?: FieldFormat | undefined;
+    /** The custom format pattern. */
+    formatPattern?: string | undefined;
+    /** The currency for numeric fields when Format is Currency. */
+    currency?: string | undefined;
+    /** A validation constraint expression for values stored in this field. */
+    constraint?: string | undefined;
+    /** The error message returned when the constraint is violated. */
+    constraintError?: string | undefined;
+    /** Whether the field supports multiple values. */
+    isMultiValue?: boolean | undefined;
+    /** Whether the field is required on entries assigned to a template containing it. */
+    isRequired?: boolean | undefined;
+    /** Whether the field is indexed for searching. */
+    isIndexed?: boolean | undefined;
+    /** Whether the field is indexed for reporting. */
+    isIndexedForReporting?: boolean | undefined;
+    /** Whether the user should be warned when leaving the field blank. */
+    warnIfBlank?: boolean | undefined;
+    /** Whether list values should be hidden in the UI. Applies only to list-backed fields. */
+    hideListValues?: boolean | undefined;
+    /** Whether values for this field can be automatically extracted by AI/OCR services. */
+    autoExtract?: boolean | undefined;
+}
+
+/** Response containing the list values of a field definition, in the order configured on the server. */
+export class ListValuesResponse implements IListValuesResponse {
+    /** The ordered list of list-item values. */
+    values?: string[] | undefined;
+
+    
+    
+    constructor(data?: IListValuesResponse) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["values"])) {
+                this.values = [] as any;
+                for (let item of _data["values"])
+                    this.values!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): ListValuesResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new ListValuesResponse();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.values)) {
+            data["values"] = [];
+            for (let item of this.values)
+                data["values"].push(item);
+        }
+        return data;
+    }
+}
+
+/** Response containing the list values of a field definition, in the order configured on the server. */
+export interface IListValuesResponse {
+    /** The ordered list of list-item values. */
+    values?: string[] | undefined;
+}
+
+/** Request body for replacing the list values of a list-backed field definition. The provided values replace the field's full list-item set wholesale, preserving the supplied order. An empty array clears the list. */
+export class ReplaceListValuesRequest implements IReplaceListValuesRequest {
+    /** The ordered list of list-item values to apply. Duplicates and empty strings are rejected with 400. */
+    values!: string[];
+
+    
+    
+    constructor(data?: IReplaceListValuesRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        if (!data) {
+            this.values = [];
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["values"])) {
+                this.values = [] as any;
+                for (let item of _data["values"])
+                    this.values!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): ReplaceListValuesRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new ReplaceListValuesRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.values)) {
+            data["values"] = [];
+            for (let item of this.values)
+                data["values"].push(item);
+        }
+        return data;
+    }
+}
+
+/** Request body for replacing the list values of a list-backed field definition. The provided values replace the field's full list-item set wholesale, preserving the supplied order. An empty array clears the list. */
+export interface IReplaceListValuesRequest {
+    /** The ordered list of list-item values to apply. Duplicates and empty strings are rejected with 400. */
+    values: string[];
+}
+
+/** Represents a template definition. */
+export class TemplateDefinition implements ITemplateDefinition {
+    /** The ID of the template definition. */
+    id?: number;
+    /** The name of the template definition. */
+    name?: string | undefined;
+    /** The localized name of the template definition. */
+    displayName?: string | undefined;
+    /** The description of the template definition. */
+    description?: string | undefined;
+    /** The color assigned to the template definition. */
+    color?: LFColor | undefined;
+    /** The number of field definitions assigned to the template definition. */
+    fieldCount?: number;
+
+    
+    
+    constructor(data?: ITemplateDefinition) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.displayName = _data["displayName"];
+            this.description = _data["description"];
+            this.color = _data["color"] ? LFColor.fromJS(_data["color"]) : <any>undefined;
+            this.fieldCount = _data["fieldCount"];
+        }
+    }
+
+    static fromJS(data: any): TemplateDefinition {
+        data = typeof data === 'object' ? data : {};
+        let result = new TemplateDefinition();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["displayName"] = this.displayName;
+        data["description"] = this.description;
+        data["color"] = this.color ? this.color.toJSON() : <any>undefined;
+        data["fieldCount"] = this.fieldCount;
+        return data;
+    }
+}
+
+/** Represents a template definition. */
+export interface ITemplateDefinition {
+    /** The ID of the template definition. */
+    id?: number;
+    /** The name of the template definition. */
+    name?: string | undefined;
+    /** The localized name of the template definition. */
+    displayName?: string | undefined;
+    /** The description of the template definition. */
+    description?: string | undefined;
+    /** The color assigned to the template definition. */
+    color?: LFColor | undefined;
+    /** The number of field definitions assigned to the template definition. */
+    fieldCount?: number;
+}
+
+/** Represents an RGB color value with alpha channel. */
+export class LFColor implements ILFColor {
+    /** The alpha channel component, from 0-255. */
+    a?: number;
+    /** The red channel component, from 0-255. */
+    r?: number;
+    /** The green channel component, from 0-255. */
+    g?: number;
+    /** The blue channel component from 0-255. */
+    b?: number;
+
+    
+    
+    constructor(data?: ILFColor) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.a = _data["a"];
+            this.r = _data["r"];
+            this.g = _data["g"];
+            this.b = _data["b"];
+        }
+    }
+
+    static fromJS(data: any): LFColor {
+        data = typeof data === 'object' ? data : {};
+        let result = new LFColor();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["a"] = this.a;
+        data["r"] = this.r;
+        data["g"] = this.g;
+        data["b"] = this.b;
+        return data;
+    }
+}
+
+/** Represents an RGB color value with alpha channel. */
+export interface ILFColor {
+    /** The alpha channel component, from 0-255. */
+    a?: number;
+    /** The red channel component, from 0-255. */
+    r?: number;
+    /** The green channel component, from 0-255. */
+    g?: number;
+    /** The blue channel component from 0-255. */
+    b?: number;
+}
+
+/** The number of entries that have a value assigned for a given field definition. */
+export class AssignedEntryCountResponse implements IAssignedEntryCountResponse {
+    /** The count of entries currently using this field. */
+    count?: number;
+
+    
+    
+    constructor(data?: IAssignedEntryCountResponse) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.count = _data["count"];
+        }
+    }
+
+    static fromJS(data: any): AssignedEntryCountResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new AssignedEntryCountResponse();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["count"] = this.count;
+        return data;
+    }
+}
+
+/** The number of entries that have a value assigned for a given field definition. */
+export interface IAssignedEntryCountResponse {
+    /** The count of entries currently using this field. */
+    count?: number;
 }
 
 /** Response containing a collection of LinkDefinition. */
@@ -11100,18 +12431,24 @@ export class Document extends Entry implements IDocument {
     isUnderVersionControl?: boolean;
     /** A boolean indicating if the represented document has a persistent lock. */
     isLocked?: boolean;
-    /** The account name of the persistent lock holder. Null if the document is not locked. */
+    /** Display name (account name, e.g. "DOMAIN\user") of the persistent lock holder. Null if the document is not locked.
+Account renames change this value over time — do not use for stable identity comparisons.
+To test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally. */
     lockedBy?: string | undefined;
     /** A boolean indicating if the document is locked by a user other than the authenticated user.
 False if the document is not locked or is locked by the authenticated user.
+Computed from a stable principal identifier comparison, not from LockedBy.
 Only populated on single-entry GET, not in listing results. */
     isLockedByAnotherUser?: boolean;
     /** The version number of the document. 0 if the document is not under version control. */
     currentVersion?: number;
-    /** The account name of the user who checked out the document. Null if the document is not checked out. */
+    /** Display name (account name, e.g. "DOMAIN\user") of the user who checked out the document. Null if the document is not checked out.
+Account renames change this value over time — do not use for stable identity comparisons.
+To test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally. */
     checkedOutBy?: string | undefined;
     /** A boolean indicating if the document is checked out by a user other than the authenticated user.
 False if the document is not checked out or is checked out by the authenticated user.
+Computed from a stable principal identifier comparison, not from CheckedOutBy.
 Only populated on single-entry GET, not in listing results. */
     isCheckedOutByAnotherUser?: boolean;
 
@@ -11196,18 +12533,24 @@ export interface IDocument extends IEntry {
     isUnderVersionControl?: boolean;
     /** A boolean indicating if the represented document has a persistent lock. */
     isLocked?: boolean;
-    /** The account name of the persistent lock holder. Null if the document is not locked. */
+    /** Display name (account name, e.g. "DOMAIN\user") of the persistent lock holder. Null if the document is not locked.
+Account renames change this value over time — do not use for stable identity comparisons.
+To test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally. */
     lockedBy?: string | undefined;
     /** A boolean indicating if the document is locked by a user other than the authenticated user.
 False if the document is not locked or is locked by the authenticated user.
+Computed from a stable principal identifier comparison, not from LockedBy.
 Only populated on single-entry GET, not in listing results. */
     isLockedByAnotherUser?: boolean;
     /** The version number of the document. 0 if the document is not under version control. */
     currentVersion?: number;
-    /** The account name of the user who checked out the document. Null if the document is not checked out. */
+    /** Display name (account name, e.g. "DOMAIN\user") of the user who checked out the document. Null if the document is not checked out.
+Account renames change this value over time — do not use for stable identity comparisons.
+To test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally. */
     checkedOutBy?: string | undefined;
     /** A boolean indicating if the document is checked out by a user other than the authenticated user.
 False if the document is not checked out or is checked out by the authenticated user.
+Computed from a stable principal identifier comparison, not from CheckedOutBy.
 Only populated on single-entry GET, not in listing results. */
     isCheckedOutByAnotherUser?: boolean;
 }
@@ -13140,7 +14483,9 @@ export interface ISetTemplateRequest {
 export class LockInfo implements ILockInfo {
     /** The unique lock token. */
     lockToken?: string | undefined;
-    /** The account name of the lock owner (e.g., "DOMAIN\user"). */
+    /** Display name (account name, e.g. "DOMAIN\user") of the lock owner.
+Same value reported as lockedBy on Document for the same lock.
+Account renames change this value over time — do not use for stable identity comparisons. */
     owner?: string | undefined;
     /** The user-defined comment for the lock. */
     comment?: string | undefined;
@@ -13199,7 +14544,9 @@ export class LockInfo implements ILockInfo {
 export interface ILockInfo {
     /** The unique lock token. */
     lockToken?: string | undefined;
-    /** The account name of the lock owner (e.g., "DOMAIN\user"). */
+    /** Display name (account name, e.g. "DOMAIN\user") of the lock owner.
+Same value reported as lockedBy on Document for the same lock.
+Account renames change this value over time — do not use for stable identity comparisons. */
     owner?: string | undefined;
     /** The user-defined comment for the lock. */
     comment?: string | undefined;
@@ -14285,138 +15632,6 @@ export interface ITemplateDefinitionCollectionResponse {
     odataCount?: number | undefined;
     /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
-}
-
-/** Represents a template definition. */
-export class TemplateDefinition implements ITemplateDefinition {
-    /** The ID of the template definition. */
-    id?: number;
-    /** The name of the template definition. */
-    name?: string | undefined;
-    /** The localized name of the template definition. */
-    displayName?: string | undefined;
-    /** The description of the template definition. */
-    description?: string | undefined;
-    /** The color assigned to the template definition. */
-    color?: LFColor | undefined;
-    /** The number of field definitions assigned to the template definition. */
-    fieldCount?: number;
-
-    
-    
-    constructor(data?: ITemplateDefinition) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property))
-                    (<any>this)[property] = (<any>data)[property];
-            }
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.id = _data["id"];
-            this.name = _data["name"];
-            this.displayName = _data["displayName"];
-            this.description = _data["description"];
-            this.color = _data["color"] ? LFColor.fromJS(_data["color"]) : <any>undefined;
-            this.fieldCount = _data["fieldCount"];
-        }
-    }
-
-    static fromJS(data: any): TemplateDefinition {
-        data = typeof data === 'object' ? data : {};
-        let result = new TemplateDefinition();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["id"] = this.id;
-        data["name"] = this.name;
-        data["displayName"] = this.displayName;
-        data["description"] = this.description;
-        data["color"] = this.color ? this.color.toJSON() : <any>undefined;
-        data["fieldCount"] = this.fieldCount;
-        return data;
-    }
-}
-
-/** Represents a template definition. */
-export interface ITemplateDefinition {
-    /** The ID of the template definition. */
-    id?: number;
-    /** The name of the template definition. */
-    name?: string | undefined;
-    /** The localized name of the template definition. */
-    displayName?: string | undefined;
-    /** The description of the template definition. */
-    description?: string | undefined;
-    /** The color assigned to the template definition. */
-    color?: LFColor | undefined;
-    /** The number of field definitions assigned to the template definition. */
-    fieldCount?: number;
-}
-
-/** Represents an RGB color value with alpha channel. */
-export class LFColor implements ILFColor {
-    /** The alpha channel component, from 0-255. */
-    a?: number;
-    /** The red channel component, from 0-255. */
-    r?: number;
-    /** The green channel component, from 0-255. */
-    g?: number;
-    /** The blue channel component from 0-255. */
-    b?: number;
-
-    
-    
-    constructor(data?: ILFColor) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property))
-                    (<any>this)[property] = (<any>data)[property];
-            }
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.a = _data["a"];
-            this.r = _data["r"];
-            this.g = _data["g"];
-            this.b = _data["b"];
-        }
-    }
-
-    static fromJS(data: any): LFColor {
-        data = typeof data === 'object' ? data : {};
-        let result = new LFColor();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["a"] = this.a;
-        data["r"] = this.r;
-        data["g"] = this.g;
-        data["b"] = this.b;
-        return data;
-    }
-}
-
-/** Represents an RGB color value with alpha channel. */
-export interface ILFColor {
-    /** The alpha channel component, from 0-255. */
-    a?: number;
-    /** The red channel component, from 0-255. */
-    r?: number;
-    /** The green channel component, from 0-255. */
-    g?: number;
-    /** The blue channel component from 0-255. */
-    b?: number;
 }
 
 /** Response containing a collection of TemplateFieldDefinition. */

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -59,7 +59,7 @@ export class AttributesClient implements IAttributesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -373,7 +373,7 @@ export class AuditReasonsClient implements IAuditReasonsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -627,7 +627,7 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -1805,7 +1805,7 @@ export class LinkDefinitionsClient implements ILinkDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -2695,7 +2695,7 @@ export class EntriesClient implements IEntriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -7735,7 +7735,7 @@ export class RepositoriesClient implements IRepositoriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -7896,7 +7896,7 @@ export class SearchesClient implements ISearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -8470,7 +8470,7 @@ export class SimpleSearchesClient implements ISimpleSearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -8650,7 +8650,7 @@ export class TagDefinitionsClient implements ITagDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -8987,7 +8987,7 @@ export class TasksClient implements ITasksClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -9354,7 +9354,7 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -596,6 +596,28 @@ export interface IFieldDefinitionsClient {
      * @returns Successfully returned the count of entries assigned to the field definition.
      */
     getFieldAssignedEntryCount(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<AssignedEntryCountResponse>;
+
+    /**
+     * - The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the extended properties for the field definition.
+     */
+    getFieldProperties(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<FieldPropertiesResponse>;
+
+    /**
+     * - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.
+    - Empty set and empty remove is a no-op and returns the current bag.
+    - Returns the full property bag after the change.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.request Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.
+     * @returns Successfully updated the extended properties for the field definition.
+     */
+    updateFieldProperties(args: { repositoryId: string, fieldId: number, request: UpdateFieldPropertiesRequest }): Promise<FieldPropertiesResponse>;
 }
 
 export class FieldDefinitionsClient implements IFieldDefinitionsClient {
@@ -1552,6 +1574,196 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
             });
         }
         return Promise.resolve<AssignedEntryCountResponse>(null as any);
+    }
+
+    /**
+     * - The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the extended properties for the field definition.
+     */
+    getFieldProperties(args: { repositoryId: string, fieldId: number, select?: string | null | undefined }): Promise<FieldPropertiesResponse> {
+        let { repositoryId, fieldId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Properties?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetFieldProperties(_response);
+        });
+    }
+
+    protected processGetFieldProperties(response: Response): Promise<FieldPropertiesResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldPropertiesResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldPropertiesResponse>(null as any);
+    }
+
+    /**
+     * - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.
+    - Empty set and empty remove is a no-op and returns the current bag.
+    - Returns the full property bag after the change.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The ID of the field definition.
+     * @param args.request Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.
+     * @returns Successfully updated the extended properties for the field definition.
+     */
+    updateFieldProperties(args: { repositoryId: string, fieldId: number, request: UpdateFieldPropertiesRequest }): Promise<FieldPropertiesResponse> {
+        let { repositoryId, fieldId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Properties";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateFieldProperties(_response);
+        });
+    }
+
+    protected processUpdateFieldProperties(response: Response): Promise<FieldPropertiesResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldPropertiesResponse.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldPropertiesResponse>(null as any);
     }
 }
 
@@ -10467,6 +10679,11 @@ use the ChangeFieldType endpoint to convert between types. */
     /** Initial list values to populate. Applies only when FieldType is List.
 Order is preserved. Use the dedicated ListValues endpoints to manage list values after creation. */
     listValues?: string[] | undefined;
+    /** Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.
+Use the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.
+For list fields, this is where the admin UI stores sort order, add-blank, add-Other,
+display-as-dropdown, and similar UI-display options. */
+    properties?: { [key: string]: string; } | undefined;
 
     
     
@@ -10503,6 +10720,13 @@ Order is preserved. Use the dedicated ListValues endpoints to manage list values
                 for (let item of _data["listValues"])
                     this.listValues!.push(item);
             }
+            if (_data["properties"]) {
+                this.properties = {} as any;
+                for (let key in _data["properties"]) {
+                    if (_data["properties"].hasOwnProperty(key))
+                        (<any>this.properties)![key] = _data["properties"][key];
+                }
+            }
         }
     }
 
@@ -10536,6 +10760,13 @@ Order is preserved. Use the dedicated ListValues endpoints to manage list values
             data["listValues"] = [];
             for (let item of this.listValues)
                 data["listValues"].push(item);
+        }
+        if (this.properties) {
+            data["properties"] = {};
+            for (let key in this.properties) {
+                if (this.properties.hasOwnProperty(key))
+                    (<any>data["properties"])[key] = (<any>this.properties)[key];
+            }
         }
         return data;
     }
@@ -10581,6 +10812,11 @@ use the ChangeFieldType endpoint to convert between types. */
     /** Initial list values to populate. Applies only when FieldType is List.
 Order is preserved. Use the dedicated ListValues endpoints to manage list values after creation. */
     listValues?: string[] | undefined;
+    /** Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.
+Use the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.
+For list fields, this is where the admin UI stores sort order, add-blank, add-Other,
+display-as-dropdown, and similar UI-display options. */
+    properties?: { [key: string]: string; } | undefined;
 }
 
 /** Request body for partial-update of an existing field definition. Every property is optional. null = leave the property unchanged. Empty string ("") on a string property = clear the value. FieldType cannot be changed via this endpoint — use the ChangeFieldType endpoint. ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints. */
@@ -10990,6 +11226,128 @@ export class AssignedEntryCountResponse implements IAssignedEntryCountResponse {
 export interface IAssignedEntryCountResponse {
     /** The count of entries currently using this field. */
     count?: number;
+}
+
+/** Response body for the extended-properties bag on a field definition. The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets. */
+export class FieldPropertiesResponse implements IFieldPropertiesResponse {
+    /** The full set of extended properties currently set on the field. */
+    properties?: { [key: string]: string; } | undefined;
+
+    
+    
+    constructor(data?: IFieldPropertiesResponse) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (_data["properties"]) {
+                this.properties = {} as any;
+                for (let key in _data["properties"]) {
+                    if (_data["properties"].hasOwnProperty(key))
+                        (<any>this.properties)![key] = _data["properties"][key];
+                }
+            }
+        }
+    }
+
+    static fromJS(data: any): FieldPropertiesResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new FieldPropertiesResponse();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (this.properties) {
+            data["properties"] = {};
+            for (let key in this.properties) {
+                if (this.properties.hasOwnProperty(key))
+                    (<any>data["properties"])[key] = (<any>this.properties)[key];
+            }
+        }
+        return data;
+    }
+}
+
+/** Response body for the extended-properties bag on a field definition. The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets. */
+export interface IFieldPropertiesResponse {
+    /** The full set of extended properties currently set on the field. */
+    properties?: { [key: string]: string; } | undefined;
+}
+
+/** Request body for partially updating the extended-properties bag on a field definition. Entries in Set are written (creating or overwriting). Entries in Remove are deleted. Properties not mentioned in either are left unchanged. */
+export class UpdateFieldPropertiesRequest implements IUpdateFieldPropertiesRequest {
+    /** Properties to set. Keys absent here are not modified. */
+    set?: { [key: string]: string; } | undefined;
+    /** Property keys to remove. Keys not currently set are ignored. */
+    remove?: string[] | undefined;
+
+    
+    
+    constructor(data?: IUpdateFieldPropertiesRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (_data["set"]) {
+                this.set = {} as any;
+                for (let key in _data["set"]) {
+                    if (_data["set"].hasOwnProperty(key))
+                        (<any>this.set)![key] = _data["set"][key];
+                }
+            }
+            if (Array.isArray(_data["remove"])) {
+                this.remove = [] as any;
+                for (let item of _data["remove"])
+                    this.remove!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): UpdateFieldPropertiesRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateFieldPropertiesRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (this.set) {
+            data["set"] = {};
+            for (let key in this.set) {
+                if (this.set.hasOwnProperty(key))
+                    (<any>data["set"])[key] = (<any>this.set)[key];
+            }
+        }
+        if (Array.isArray(this.remove)) {
+            data["remove"] = [];
+            for (let item of this.remove)
+                data["remove"].push(item);
+        }
+        return data;
+    }
+}
+
+/** Request body for partially updating the extended-properties bag on a field definition. Entries in Set are written (creating or overwriting). Entries in Remove are deleted. Properties not mentioned in either are left unchanged. */
+export interface IUpdateFieldPropertiesRequest {
+    /** Properties to set. Keys absent here are not modified. */
+    set?: { [key: string]: string; } | undefined;
+    /** Property keys to remove. Keys not currently set are ignored. */
+    remove?: string[] | undefined;
 }
 
 /** Response containing a collection of LinkDefinition. */

--- a/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
+++ b/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
@@ -7,6 +7,7 @@ import {
   FieldType,
   ReplaceListValuesRequest,
   UpdateFieldDefinitionRequest,
+  UpdateFieldPropertiesRequest,
 } from '../../index.js';
 
 function uniqueName(prefix: string): string {
@@ -145,6 +146,64 @@ describe('Field Definition Admin Integration Tests', () => {
 
       expect(containing).not.toBeNull();
       expect(containing.length).toBe(0);
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
+
+  test('Extended properties — create / get / update round-trip', async () => {
+    const fieldName = uniqueName('client_test_props_field');
+    let createdId = 0;
+    try {
+      // Create with an initial property set — atomic with the create call.
+      const initialProps: { [key: string]: string } = {
+        'lf-cli-test-key1': 'alpha',
+        'lf-cli-test-key2': 'beta',
+      };
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.String,
+          length: 25,
+          properties: initialProps,
+        }),
+      });
+      createdId = created.id!;
+
+      // GET — bag should include the two keys we set on Create.
+      const bag = await _RepositoryApiClient.fieldDefinitionsClient.getFieldProperties({
+        repositoryId,
+        fieldId: createdId,
+      });
+      expect(bag.properties?.['lf-cli-test-key1']).toBe('alpha');
+      expect(bag.properties?.['lf-cli-test-key2']).toBe('beta');
+
+      // PATCH — set one new key, remove one of the existing keys.
+      const afterUpdate = await _RepositoryApiClient.fieldDefinitionsClient.updateFieldProperties({
+        repositoryId,
+        fieldId: createdId,
+        request: new UpdateFieldPropertiesRequest({
+          set: { 'lf-cli-test-key3': 'gamma' },
+          remove: ['lf-cli-test-key1'],
+        }),
+      });
+      expect(afterUpdate.properties?.['lf-cli-test-key1']).toBeUndefined();
+      expect(afterUpdate.properties?.['lf-cli-test-key2']).toBe('beta');
+      expect(afterUpdate.properties?.['lf-cli-test-key3']).toBe('gamma');
+
+      // Independent GET — verify the PATCH persisted (defense against same-request masking).
+      const afterUpdateReread = await _RepositoryApiClient.fieldDefinitionsClient.getFieldProperties({
+        repositoryId,
+        fieldId: createdId,
+      });
+      expect(afterUpdateReread.properties?.['lf-cli-test-key1']).toBeUndefined();
+      expect(afterUpdateReread.properties?.['lf-cli-test-key3']).toBe('gamma');
     } finally {
       if (createdId > 0) {
         await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({

--- a/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
+++ b/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
@@ -95,12 +95,25 @@ describe('Field Definition Admin Integration Tests', () => {
       });
       expect(afterReplace.values).toEqual(replacement);
 
+      // Independent GET — proves the PUT persisted; same-request reads can mask a missing Save() (Trap 4).
+      const afterReplaceReread = await _RepositoryApiClient.fieldDefinitionsClient.getFieldListValues({
+        repositoryId,
+        fieldId: createdId,
+      });
+      expect(afterReplaceReread.values).toEqual(replacement);
+
       const afterClear = await _RepositoryApiClient.fieldDefinitionsClient.replaceFieldListValues({
         repositoryId,
         fieldId: createdId,
         request: new ReplaceListValuesRequest({ values: [] }),
       });
       expect(afterClear.values?.length ?? -1).toBe(0);
+
+      const afterClearReread = await _RepositoryApiClient.fieldDefinitionsClient.getFieldListValues({
+        repositoryId,
+        fieldId: createdId,
+      });
+      expect(afterClearReread.values?.length ?? -1).toBe(0);
     } finally {
       if (createdId > 0) {
         await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({

--- a/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
+++ b/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
@@ -1,0 +1,175 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId } from '../TestHelper.js';
+import { _RepositoryApiClient } from '../CreateSession.js';
+import {
+  CreateFieldDefinitionRequest,
+  FieldType,
+  ReplaceListValuesRequest,
+  UpdateFieldDefinitionRequest,
+} from '../../index.js';
+
+function uniqueName(prefix: string): string {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:T.Z]/g, '')
+    .slice(0, 17);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${prefix}_${stamp}_${rand}`;
+}
+
+describe('Field Definition Admin Integration Tests', () => {
+  test('Create / Update / Delete string-field lifecycle', async () => {
+    const fieldName = uniqueName('client_test_field');
+    let createdId = 0;
+    try {
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.String,
+          length: 50,
+          description: 'Created from JS client integration test',
+          isIndexed: true,
+          warnIfBlank: true,
+        }),
+      });
+
+      expect(created).not.toBeNull();
+      expect(created.id ?? 0).toBeGreaterThan(0);
+      expect(created.name).toBe(fieldName);
+      expect(created.fieldType).toBe(FieldType.String);
+      expect(created.isIndexed).toBe(true);
+      expect(created.warnIfBlank).toBe(true);
+      createdId = created.id!;
+
+      const updated = await _RepositoryApiClient.fieldDefinitionsClient.updateFieldDefinition({
+        repositoryId,
+        fieldId: createdId,
+        request: new UpdateFieldDefinitionRequest({
+          description: 'Updated description',
+          isRequired: true,
+        }),
+      });
+
+      expect(updated.description).toBe('Updated description');
+      expect(updated.isRequired).toBe(true);
+      expect(updated.name).toBe(fieldName); // not in PATCH — preserved
+      expect(updated.isIndexed).toBe(true); // not in PATCH — preserved
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
+
+  test('List field — replace list values round-trip', async () => {
+    const fieldName = uniqueName('client_test_list_field');
+    let createdId = 0;
+    try {
+      const initial = ['Alpha', 'Beta', 'Gamma'];
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.List,
+          listValues: initial,
+        }),
+      });
+      createdId = created.id!;
+
+      const listed = await _RepositoryApiClient.fieldDefinitionsClient.getFieldListValues({
+        repositoryId,
+        fieldId: createdId,
+      });
+      expect(listed.values).toEqual(initial);
+
+      const replacement = ['One', 'Two', 'Three', 'Four'];
+      const afterReplace = await _RepositoryApiClient.fieldDefinitionsClient.replaceFieldListValues({
+        repositoryId,
+        fieldId: createdId,
+        request: new ReplaceListValuesRequest({ values: replacement }),
+      });
+      expect(afterReplace.values).toEqual(replacement);
+
+      const afterClear = await _RepositoryApiClient.fieldDefinitionsClient.replaceFieldListValues({
+        repositoryId,
+        fieldId: createdId,
+        request: new ReplaceListValuesRequest({ values: [] }),
+      });
+      expect(afterClear.values?.length ?? -1).toBe(0);
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
+
+  test('GetContainingTemplates — field not in any template returns empty', async () => {
+    const fieldName = uniqueName('client_test_orphan_field');
+    let createdId = 0;
+    try {
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.String,
+          length: 10,
+        }),
+      });
+      createdId = created.id!;
+
+      const containing = await _RepositoryApiClient.fieldDefinitionsClient.getFieldContainingTemplates({
+        repositoryId,
+        fieldId: createdId,
+      });
+
+      expect(containing).not.toBeNull();
+      expect(containing.length).toBe(0);
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
+
+  test('GetAssignedEntryCount — brand-new field returns zero', async () => {
+    const fieldName = uniqueName('client_test_unassigned_field');
+    let createdId = 0;
+    try {
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.String,
+          length: 10,
+        }),
+      });
+      createdId = created.id!;
+
+      const count = await _RepositoryApiClient.fieldDefinitionsClient.getFieldAssignedEntryCount({
+        repositoryId,
+        fieldId: createdId,
+      });
+
+      expect(count).not.toBeNull();
+      expect(count.count).toBe(0);
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
+});

--- a/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
+++ b/packages/lf-repository-api-client-v2/test/FieldDefinitions/FieldDefinitionAdmin.test.ts
@@ -244,4 +244,187 @@ describe('Field Definition Admin Integration Tests', () => {
       }
     }
   });
+
+  // ---- Coverage tests added during pre-PR review ----
+
+  // Test #1: end-to-end round-trip for every FieldType, mirrors the dotnet integration test.
+  // Iterates 8 types (Blob skipped — historically not exercised via the admin API).
+  test('All FieldTypes — create / describe / update round-trip', async () => {
+    const types = [
+      FieldType.String,
+      FieldType.List,
+      FieldType.Number,
+      FieldType.Date,
+      FieldType.DateTime,
+      FieldType.Time,
+      FieldType.ShortInteger,
+      FieldType.LongInteger,
+    ];
+
+    for (const fieldType of types) {
+      const fieldName = uniqueName(`client_test_type_${fieldType}`);
+      let createdId = 0;
+      try {
+        const reqInit: any = {
+          name: fieldName,
+          fieldType,
+          description: `Round-trip test for ${fieldType}`,
+        };
+        if (fieldType === FieldType.String || fieldType === FieldType.List) {
+          reqInit.length = 25;
+        }
+        if (fieldType === FieldType.List) {
+          reqInit.listValues = ['Alpha', 'Beta'];
+        }
+        const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+          repositoryId,
+          request: new CreateFieldDefinitionRequest(reqInit),
+        });
+        expect(created.id ?? 0, `${fieldType}: id`).toBeGreaterThan(0);
+        expect(created.fieldType, `${fieldType}: round-tripped type`).toBe(fieldType);
+        createdId = created.id!;
+
+        // Independent GET — defense against same-request masking (Trap 4).
+        const fetched = await _RepositoryApiClient.fieldDefinitionsClient.getFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+        expect(fetched.fieldType).toBe(fieldType);
+        expect(fetched.description).toBe(`Round-trip test for ${fieldType}`);
+
+        // PATCH description; verify regardless of type.
+        const updated = await _RepositoryApiClient.fieldDefinitionsClient.updateFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+          request: new UpdateFieldDefinitionRequest({
+            description: `Updated for ${fieldType}`,
+          }),
+        });
+        expect(updated.description, `${fieldType}: PATCH didn't stick`).toBe(`Updated for ${fieldType}`);
+      } finally {
+        if (createdId > 0) {
+          await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+            repositoryId,
+            fieldId: createdId,
+          });
+        }
+      }
+    }
+  });
+
+  // Test #2: GET /Properties on a fresh field with no caller-set properties.
+  // Surfaces what LFS-internal keys (if any) come back — closes Codex round-3
+  // finding #4 with empirical evidence.
+  test('GetFieldProperties — fresh field documents LFS-internal entries', async () => {
+    const fieldName = uniqueName('client_test_props_probe');
+    let createdId = 0;
+    try {
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.String,
+          length: 10,
+          // no properties supplied
+        }),
+      });
+      createdId = created.id!;
+
+      const bag = await _RepositoryApiClient.fieldDefinitionsClient.getFieldProperties({
+        repositoryId,
+        fieldId: createdId,
+      });
+      expect(bag).not.toBeNull();
+      expect(bag.properties).not.toBeUndefined();
+
+      // Record entries for triage — visible in vitest output on verbose mode.
+      const entries = Object.entries(bag.properties ?? {});
+      console.log(`GetFieldProperties on fresh field returned ${entries.length} entries:`);
+      for (const [k, v] of entries) {
+        console.log(`  [${k}] = [${v}]`);
+      }
+      for (const [k] of entries) {
+        expect(k.length, `LFS returned an empty property key`).toBeGreaterThan(0);
+        expect(k.length, `LFS returned an oversized property key: '${k}'`).toBeLessThanOrEqual(256);
+      }
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
+
+  // Test #3: server-side 400 validations surface through the JS client as ApiException
+  // with parseable problemDetails. Covers a sample of round-1/2/3 validation tightenings.
+  test('Validation — round-trips as 400 problemDetails', async () => {
+    // length=0 on Create → 400
+    await expect(
+      _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: uniqueName('client_test_invalid'),
+          fieldType: FieldType.String,
+          length: 0,
+        }),
+      })
+    ).rejects.toMatchObject({ status: 400 });
+
+    // listValues on a non-List type → 400
+    await expect(
+      _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: uniqueName('client_test_invalid'),
+          fieldType: FieldType.String,
+          length: 10,
+          listValues: ['A', 'B'],
+        }),
+      })
+    ).rejects.toMatchObject({ status: 400 });
+
+    const fieldName = uniqueName('client_test_props_validation');
+    let createdId = 0;
+    try {
+      const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+        repositoryId,
+        request: new CreateFieldDefinitionRequest({
+          name: fieldName,
+          fieldType: FieldType.String,
+          length: 10,
+        }),
+      });
+      createdId = created.id!;
+
+      // PATCH /Properties empty-key → 400
+      await expect(
+        _RepositoryApiClient.fieldDefinitionsClient.updateFieldProperties({
+          repositoryId,
+          fieldId: createdId,
+          request: new UpdateFieldPropertiesRequest({ set: { '': 'v' } }),
+        })
+      ).rejects.toMatchObject({ status: 400 });
+
+      // PATCH /Properties same key in set + remove → 400
+      await expect(
+        _RepositoryApiClient.fieldDefinitionsClient.updateFieldProperties({
+          repositoryId,
+          fieldId: createdId,
+          request: new UpdateFieldPropertiesRequest({
+            set: { shared: 'v' },
+            remove: ['shared'],
+          }),
+        })
+      ).rejects.toMatchObject({ status: 400 });
+    } finally {
+      if (createdId > 0) {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({
+          repositoryId,
+          fieldId: createdId,
+        });
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Regenerates `@laserfiche/lf-repository-api-client-v2` to pick up the 9 new Field Definition Admin endpoints introduced by the server PR for PRD §6.3.A (REQ-ADMIN-001..004 + REQ-ADMIN-004B). Companion PR for site-api-repository (TFS), US #666940.

New surface on `IFieldDefinitionsClient`:
- `createFieldDefinition` / `updateFieldDefinition` / `deleteFieldDefinition`
- `getFieldListValues` / `replaceFieldListValues`
- `getFieldContainingTemplates` / `getFieldAssignedEntryCount`
- `getFieldProperties` / `updateFieldProperties`

Plus new DTOs:
- `CreateFieldDefinitionRequest` / `UpdateFieldDefinitionRequest`
- `ReplaceListValuesRequest` / `ListValuesResponse`
- `AssignedEntryCountResponse`
- `FieldPropertiesResponse` / `UpdateFieldPropertiesRequest`

Five additive writable flags on `FieldDefinition`: `isIndexed`, `isIndexedForReporting`, `warnIfBlank`, `hideListValues`, `autoExtract`.

## Test plan

- [x] Build clean (`npm run build`)
- [x] TypeScript typecheck clean (`tsc --noEmit -p tsconfig.json`)
- [x] **8/8 vitest integration tests** pass against a local server with the companion server PR's branch (`FieldDefinitionAdmin.test.ts`):
  - String lifecycle (Create/Update/Delete)
  - List field Replace round-trip (with independent GET re-reads)
  - GetContainingTemplates empty case
  - GetAssignedEntryCount zero case
  - Extended Properties Create/Get/Update round-trip
  - All 8 non-Blob `FieldType` enum values round-tripped
  - GET Properties on a fresh field documents LFS-internal entries (empirically 0 on dev-CA)
  - Server-side 400 validations surface with `status: 400`

## Notes for reviewers

- `.env` `APISERVER_REPOSITORY_API_BASE_URL` must have **no trailing slash** (per Trap 2 in `.claude/skills/regen-js-client/SKILL.md`); session-level discovery `lf-cli-test-key1`-style keys for the integration tests work fine.
- Companion PRs:
  - site-api-repository TFS PR #171879
  - lf-repository-api-client-dotnet #202

Related: PRD `notes/PRD - Repository REST API V2 Surface Expansion.md` §6.3.A, TFS US #666940