### PR TITLE
Regenerate V2 client + tests for 6.4.B/C/D field/template access-rights, session rights, trustee effective security

### DIFF
--- a/packages/lf-repository-api-client-v2/ClientBase.ts
+++ b/packages/lf-repository-api-client-v2/ClientBase.ts
@@ -25,6 +25,7 @@ export interface IRepositoryApiClient {
   tasksClient: generated.ITasksClient;
   templateDefinitionsClient: ITemplateDefinitionsClient;
   linkDefinitionsClient: ILinkDefinitionsClient;
+  trusteesClient: generated.ITrusteesClient;
   defaultRequestHeaders: Record<string, string>;
 }
 
@@ -43,6 +44,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
   public tasksClient: generated.ITasksClient;
   public templateDefinitionsClient: ITemplateDefinitionsClient;
   public linkDefinitionsClient: ILinkDefinitionsClient;
+  public trusteesClient: generated.ITrusteesClient;
 
   private repoClientHandler: RepositoryApiClientHttpHandler;
 
@@ -82,6 +84,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
     this.tasksClient = new generated.TasksClient(this.baseUrl, http);
     this.templateDefinitionsClient = new TemplateDefinitionsClient(this.baseUrl, http);
     this.linkDefinitionsClient = new LinkDefinitionsClient(this.baseUrl, http);
+    this.trusteesClient = new generated.TrusteesClient(this.baseUrl, http);
   }
 
   /**

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -1965,6 +1965,536 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AccessControl": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Returns the field's access control entries (ACEs): the trustee, whether rights are allowed or denied, and the rights themselves. Field ACEs have no scope and are never inherited.\n- The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the field's ReadPermissions right.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The requested field definition ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the field definition's access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Full replace: the supplied entries replace the field's entire explicit ACL. Inherited entries are not accepted (field ACEs are never inherited). Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given; an account name is resolved to a SID server-side).\n- The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the field's ChangePermissions right.\n- Required OAuth scope: repository.Write",
+        "operationId": "SetFieldAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The field definition ID whose ACL to replace.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The access control entries to set.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetFieldAccessControlRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the field definition's access control list. Returned the updated access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Rights": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Returns the rights a trustee has on the field definition, plus whether the session is read-only. By default these are the effective rights (after group membership, allow/deny resolution, and the privilege overlay); set aclOnly=true for the rights granted by the field's own ACL without that overlay. Omit both trusteeId and trusteeName for the current session.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldRights",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The requested field definition ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "trusteeId",
+            "in": "query",
+            "description": "An optional trustee SID. When supplied, returns that trustee's rights; otherwise the current session's.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "trusteeName",
+            "in": "query",
+            "description": "An optional trustee account name, as an alternative to trusteeId. The SID wins when both are supplied.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "aclOnly",
+            "in": "query",
+            "description": "Optional. Selects which rights are returned. Default (false): the trustee's effective rights \u2014 the net result after allow/deny resolution, group membership, and the repository's privilege overlay (for example, the metadata-management privilege that grants full control over every field regardless of its ACL). When true: only the rights granted by this field definition's own access control list, without that privilege overlay. Group membership is always resolved. Field definitions are not hierarchical, so there is no parent inheritance involved either way.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the rights for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldRights"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/DefaultAccessControl": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Returns the repository's default field ACL \u2014 the access control entries a new field definition inherits at creation time.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetDefaultFieldAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the default field access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "- Full replace: the supplied entries replace the entire default field ACL. Inherited entries are not accepted. Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given).\n- Required OAuth scope: repository.Write",
+        "operationId": "SetDefaultFieldAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The access control entries to set as the default field ACL.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetFieldAccessControlRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the default field access control list. Returned the updated default access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/LinkDefinitions": {
       "get": {
         "tags": [
@@ -8834,6 +9364,89 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/SessionRights": {
+      "get": {
+        "tags": [
+          "Repositories"
+        ],
+        "summary": "- Returns the privileges and feature rights held by the current session, plus whether the session is read-only. Each is reported as named booleans (a map of right name to whether it is granted), for UI enablement and pre-flight checks.\n- Reflects the current session only. Per-trustee privilege administration is not part of this surface.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetSessionRights",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the current session's rights.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionRights"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/Searches/SearchAsync": {
       "post": {
         "tags": [
@@ -11952,6 +12565,536 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AccessControl": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "- Returns the template's access control entries (ACEs): the trustee, whether rights are allowed or denied, and the rights themselves. Template ACEs have no scope and are never inherited.\n- The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the template's ReadPermissions right.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTemplateAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The requested template definition ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the template definition's access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "- Full replace: the supplied entries replace the template's entire explicit ACL. Inherited entries are not accepted (template ACEs are never inherited). Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given; an account name is resolved to a SID server-side).\n- The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the template's ChangePermissions right.\n- Required OAuth scope: repository.Write",
+        "operationId": "SetTemplateAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The template definition ID whose ACL to replace.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The access control entries to set.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTemplateAccessControlRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the template definition's access control list. Returned the updated access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Rights": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "- Returns the rights a trustee has on the template definition, plus whether the session is read-only. By default these are the effective rights (after group membership, allow/deny resolution, and the privilege overlay); set aclOnly=true for the rights granted by the template's own ACL without that overlay. Omit both trusteeId and trusteeName for the current session.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTemplateRights",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The requested template definition ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "trusteeId",
+            "in": "query",
+            "description": "An optional trustee SID. When supplied, returns that trustee's rights; otherwise the current session's.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "trusteeName",
+            "in": "query",
+            "description": "An optional trustee account name, as an alternative to trusteeId. The SID wins when both are supplied.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "aclOnly",
+            "in": "query",
+            "description": "Optional. Selects which rights are returned. Default (false): the trustee's effective rights \u2014 the net result after allow/deny resolution, group membership, and the repository's privilege overlay (for example, the metadata-management privilege that grants full control over every template regardless of its ACL). When true: only the rights granted by this template definition's own access control list, without that privilege overlay. Group membership is always resolved. Template definitions are not hierarchical, so there is no parent inheritance involved either way.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the rights for the template definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateRights"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/DefaultAccessControl": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "- Returns the repository's default template ACL \u2014 the access control entries a new template definition inherits at creation time.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetDefaultTemplateAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the default template access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "- Full replace: the supplied entries replace the entire default template ACL. Inherited entries are not accepted. Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given).\n- Required OAuth scope: repository.Write",
+        "operationId": "SetDefaultTemplateAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The access control entries to set as the default template ACL.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTemplateAccessControlRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the default template access control list. Returned the updated default access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateAccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/Trustees": {
       "get": {
         "tags": [
@@ -12038,6 +13181,109 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Trustees/{trusteeId}/EffectiveSecurity": {
+      "get": {
+        "tags": [
+          "Trustees"
+        ],
+        "summary": "- Returns the trustee's effective privileges and feature rights (as named booleans), the security tags assigned to it, the audit classes configured for it (split into success and failure masks), and whether the trustee is read-only.\n- This is a best-effort computation that can, in rare cases, differ from the trustee's real rights. The authoritative way to determine a trustee's security is to sign in as that trustee and read the resulting session's rights.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTrusteeEffectiveSecurity",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "trusteeId",
+            "in": "path",
+            "required": true,
+            "description": "The SID of the trustee whose effective security is computed. Use the trustee lookup to resolve a name to a SID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the trustee's effective account security.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrusteeEffectiveSecurity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -13011,6 +14257,224 @@
           "allowDataLoss": {
             "type": "boolean",
             "description": "Acknowledges that the requested conversion will lose data and authorizes it to proceed.\nRequired (must be true) when any of the following hold: leaving the List type\n(clears list items); the field has a non-empty constraint, a defaultValue,\nor any assigned entries, AND the conversion is not one of the explicit safe widenings\n(Date \u2192 DateTime, ShortInteger \u2192 LongInteger, ShortInteger \u2192 Number,\nLongInteger \u2192 Number). A lossy conversion without this flag returns 400\n(data_loss_expected). Lossless conversions ignore this flag."
+          }
+        }
+      },
+      "FieldAccessControlList": {
+        "type": "object",
+        "description": "The access control list (ACL) of a template field definition: its access control entries.\nField ACLs have no parent inheritance, so there is no inherit-parents flag.",
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "The access control entries that make up the ACL.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/FieldAccessControlEntry"
+            }
+          }
+        }
+      },
+      "FieldAccessControlEntry": {
+        "type": "object",
+        "description": "A single access control entry (ACE) on a template field definition: one trustee, whether\nits rights are allowed or denied, and the rights themselves. A trustee that has both allowed\nand denied rights is represented as two ACEs. Unlike entry ACEs, field ACEs have no scope and\nare never inherited.",
+        "additionalProperties": false,
+        "properties": {
+          "trustee": {
+            "description": "The trustee this ACE applies to. On input, identify the trustee by either\ntrustee.sid or trustee.accountName (the SID takes precedence when both are given).",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrusteeIdentity"
+              }
+            ]
+          },
+          "accessControlType": {
+            "description": "Whether the ACE grants (Allow) or denies (Deny) the listed rights. Required on\ninput \u2014 a missing value is rejected (it must not silently default to Allow).",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AccessControlType"
+              }
+            ]
+          },
+          "rights": {
+            "type": "array",
+            "description": "The rights granted or denied by this ACE.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/FieldRight"
+            }
+          },
+          "isInherited": {
+            "type": "boolean",
+            "description": "True when this ACE is inherited. Always false for field ACEs (field definitions have no\nACL inheritance); returned for contract symmetry and ignored on input."
+          },
+          "inheritedFrom": {
+            "type": "string",
+            "description": "When inherited, a description of where the ACE was inherited from. Output only; null for\nfield ACEs.",
+            "nullable": true
+          }
+        }
+      },
+      "TrusteeIdentity": {
+        "type": "object",
+        "description": "Identifies a security trustee (a user or a group) referenced by an access control\nentry, an effective-rights query, or a trustee-lookup result.",
+        "additionalProperties": false,
+        "properties": {
+          "sid": {
+            "type": "string",
+            "description": "The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is\nthe canonical, stable id for a trustee. On input it is preferred and takes precedence over\nAccountName; always populated on output.",
+            "nullable": true
+          },
+          "accountName": {
+            "type": "string",
+            "description": "The trustee's account name. On input it may be supplied instead of Sid to\naddress the trustee by name (resolved to a SID server-side); the SID wins when both are\ngiven. Always populated on output.",
+            "nullable": true
+          },
+          "trusteeType": {
+            "type": "string",
+            "description": "The trustee type: one of LaserficheUser, LaserficheGroup,\nWindowsAccount, LdapAccount, LfdsAccount.",
+            "nullable": true
+          },
+          "isUser": {
+            "type": "boolean",
+            "description": "True when the trustee is an individual user; false when it is a group."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "A human-readable display name. Populated by trustee-lookup results; omitted in\naccess-control-entry contexts.",
+            "nullable": true
+          },
+          "isDisabled": {
+            "type": "boolean",
+            "description": "True when the trustee account is disabled. Populated by trustee-lookup results."
+          }
+        }
+      },
+      "AccessControlType": {
+        "type": "string",
+        "description": "Whether an access control entry (ACE) grants or denies its rights. Serialized by name.",
+        "x-enum-names": [
+          "Allow",
+          "Deny"
+        ],
+        "x-enum-varnames": [
+          "Allow",
+          "Deny"
+        ],
+        "x-enumNames": [
+          "Allow",
+          "Deny"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null
+        ],
+        "enum": [
+          "Allow",
+          "Deny"
+        ]
+      },
+      "FieldRight": {
+        "type": "string",
+        "description": "An individual access right that can be granted to or denied a trustee on a template field\ndefinition. Serialized by name; emitted as a string enum in the OpenAPI schema so clients\ncan reference it directly.",
+        "x-enum-names": [
+          "ReadValue",
+          "SetValue",
+          "SetValueOnce",
+          "ModifyDefinition",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enum-varnames": [
+          "ReadValue",
+          "SetValue",
+          "SetValueOnce",
+          "ModifyDefinition",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enumNames": [
+          "ReadValue",
+          "SetValue",
+          "SetValueOnce",
+          "ModifyDefinition",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "ReadValue",
+          "SetValue",
+          "SetValueOnce",
+          "ModifyDefinition",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ]
+      },
+      "SetFieldAccessControlRequest": {
+        "type": "object",
+        "description": "Request body for replacing a template field definition's access control list. The supplied\nentries fully replace the field's existing explicit ACL. Inherited entries are not accepted.",
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "The access control entries to set. Replaces the field's entire explicit ACL.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/FieldAccessControlEntry"
+            }
+          }
+        }
+      },
+      "FieldRights": {
+        "type": "object",
+        "description": "A trustee's rights to a template field definition. Depending on the aclOnly option on the\nrequest, these are either the effective rights (the net result after group membership, allow/deny\nresolution, and the repository's privilege overlay) or the rights granted by the field's access\ncontrol list alone.",
+        "additionalProperties": false,
+        "properties": {
+          "rights": {
+            "type": "array",
+            "description": "The rights granted to the trustee on the field.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/FieldRight"
+            }
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "True when the session is read-only, so no write operations are possible regardless of\nthe granted rights."
           }
         }
       },
@@ -15134,69 +16598,6 @@
           }
         }
       },
-      "TrusteeIdentity": {
-        "type": "object",
-        "description": "Identifies a security trustee (a user or a group) referenced by an access control\nentry, an effective-rights query, or a trustee-lookup result.",
-        "additionalProperties": false,
-        "properties": {
-          "sid": {
-            "type": "string",
-            "description": "The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is\nthe canonical, stable id for a trustee. On input it is preferred and takes precedence over\nAccountName; always populated on output.",
-            "nullable": true
-          },
-          "accountName": {
-            "type": "string",
-            "description": "The trustee's account name. On input it may be supplied instead of Sid to\naddress the trustee by name (resolved to a SID server-side); the SID wins when both are\ngiven. Always populated on output.",
-            "nullable": true
-          },
-          "trusteeType": {
-            "type": "string",
-            "description": "The trustee type: one of LaserficheUser, LaserficheGroup,\nWindowsAccount, LdapAccount, LfdsAccount.",
-            "nullable": true
-          },
-          "isUser": {
-            "type": "boolean",
-            "description": "True when the trustee is an individual user; false when it is a group."
-          },
-          "displayName": {
-            "type": "string",
-            "description": "A human-readable display name. Populated by trustee-lookup results; omitted in\naccess-control-entry contexts.",
-            "nullable": true
-          },
-          "isDisabled": {
-            "type": "boolean",
-            "description": "True when the trustee account is disabled. Populated by trustee-lookup results."
-          }
-        }
-      },
-      "AccessControlType": {
-        "type": "string",
-        "description": "Whether an access control entry (ACE) grants or denies its rights. Serialized by name.",
-        "x-enum-names": [
-          "Allow",
-          "Deny"
-        ],
-        "x-enum-varnames": [
-          "Allow",
-          "Deny"
-        ],
-        "x-enumNames": [
-          "Allow",
-          "Deny"
-        ],
-        "x-enum-descriptions": [
-          null,
-          null
-        ],
-        "x-enumDescriptions": [
-          null,
-          null
-        ],
-        "enum": [
-          "Allow",
-          "Deny"
-        ]
-      },
       "EntryRight": {
         "type": "string",
         "description": "An individual access right that can be granted to or denied a trustee on an entry.\nSerialized by name; emitted as a string enum in the OpenAPI schema so clients can\nreference it directly.",
@@ -15476,6 +16877,33 @@
             "type": "string",
             "description": "The corresponding repository Web Client url.",
             "nullable": true
+          }
+        }
+      },
+      "SessionRights": {
+        "type": "object",
+        "description": "The current session's rights in a repository: the privileges and feature rights held by the\nsession, plus whether the session is read-only. Reported as named booleans (each map is keyed\nby the right's name with a granted true/false) rather than a raw bitmask, for UI enablement\nand pre-flight checks. Reflects the current session only \u2014 per-trustee privilege administration\nis not part of this surface.",
+        "additionalProperties": false,
+        "properties": {
+          "privileges": {
+            "type": "object",
+            "description": "The session's privileges, keyed by privilege name (e.g. EntryAccess,\nRecordManager), with the value indicating whether the session holds that privilege.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "featureRights": {
+            "type": "object",
+            "description": "The session's feature rights, keyed by feature-right name (e.g. Search,\nImport), with the value indicating whether the session holds that feature right.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "True when the current session is read-only, so no write operations are possible regardless\nof the granted privileges or feature rights."
           }
         }
       },
@@ -16376,6 +17804,237 @@
             "type": "integer",
             "description": "The 1-based target position. Required. Values less than 1 or greater than the\ncurrent field count are rejected with 400.",
             "format": "int32"
+          }
+        }
+      },
+      "TemplateAccessControlList": {
+        "type": "object",
+        "description": "The access control list (ACL) of a template definition: its access control entries.\nTemplate ACLs have no parent inheritance, so there is no inherit-parents flag.",
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "The access control entries that make up the ACL.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TemplateAccessControlEntry"
+            }
+          }
+        }
+      },
+      "TemplateAccessControlEntry": {
+        "type": "object",
+        "description": "A single access control entry (ACE) on a template definition: one trustee, whether its\nrights are allowed or denied, and the rights themselves. A trustee that has both allowed\nand denied rights is represented as two ACEs. Unlike entry ACEs, template ACEs have no scope\nand are never inherited.",
+        "additionalProperties": false,
+        "properties": {
+          "trustee": {
+            "description": "The trustee this ACE applies to. On input, identify the trustee by either\ntrustee.sid or trustee.accountName (the SID takes precedence when both are given).",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrusteeIdentity"
+              }
+            ]
+          },
+          "accessControlType": {
+            "description": "Whether the ACE grants (Allow) or denies (Deny) the listed rights. Required on\ninput \u2014 a missing value is rejected (it must not silently default to Allow).",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AccessControlType"
+              }
+            ]
+          },
+          "rights": {
+            "type": "array",
+            "description": "The rights granted or denied by this ACE.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TemplateRight"
+            }
+          },
+          "isInherited": {
+            "type": "boolean",
+            "description": "True when this ACE is inherited. Always false for template ACEs (template definitions have\nno ACL inheritance); returned for contract symmetry and ignored on input."
+          },
+          "inheritedFrom": {
+            "type": "string",
+            "description": "When inherited, a description of where the ACE was inherited from. Output only; null for\ntemplate ACEs.",
+            "nullable": true
+          }
+        }
+      },
+      "TemplateRight": {
+        "type": "string",
+        "description": "An individual access right that can be granted to or denied a trustee on a template\ndefinition. Serialized by name; emitted as a string enum in the OpenAPI schema so clients\ncan reference it directly.",
+        "x-enum-names": [
+          "ReadDefinition",
+          "Modify",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enum-varnames": [
+          "ReadDefinition",
+          "Modify",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enumNames": [
+          "ReadDefinition",
+          "Modify",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "ReadDefinition",
+          "Modify",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ]
+      },
+      "SetTemplateAccessControlRequest": {
+        "type": "object",
+        "description": "Request body for replacing a template definition's access control list. The supplied\nentries fully replace the template's existing explicit ACL. Inherited entries are not accepted.",
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "The access control entries to set. Replaces the template's entire explicit ACL.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TemplateAccessControlEntry"
+            }
+          }
+        }
+      },
+      "TemplateRights": {
+        "type": "object",
+        "description": "A trustee's rights to a template definition. Depending on the aclOnly option on the\nrequest, these are either the effective rights (the net result after group membership, allow/deny\nresolution, and the repository's privilege overlay) or the rights granted by the template's access\ncontrol list alone.",
+        "additionalProperties": false,
+        "properties": {
+          "rights": {
+            "type": "array",
+            "description": "The rights granted to the trustee on the template.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TemplateRight"
+            }
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "True when the session is read-only, so no write operations are possible regardless of\nthe granted rights."
+          }
+        }
+      },
+      "TrusteeEffectiveSecurity": {
+        "type": "object",
+        "description": "The effective account security that applies when a trustee logs in to a repository: the\nprivileges and feature rights the trustee holds, the security tags assigned to it, the audit\nclasses configured for it, and whether the trustee is read-only. Privileges, feature rights,\nand audit masks are reported as named booleans (each map keyed by the right's name with a\ngranted true/false) rather than raw bitmasks.\nThis is a documented best-effort computation: in rare cases it can differ from the trustee's\nreal rights. The authoritative way to determine a trustee's security is to sign in as that\ntrustee and read the resulting session's rights. Values reflect effective (not direct) security.",
+        "additionalProperties": false,
+        "properties": {
+          "privileges": {
+            "type": "object",
+            "description": "The trustee's privileges, keyed by privilege name (e.g. EntryAccess,\nRecordManager), with the value indicating whether the trustee holds that privilege.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "featureRights": {
+            "type": "object",
+            "description": "The trustee's feature rights, keyed by feature-right name (e.g. Search,\nImport), with the value indicating whether the trustee holds that feature right.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "True when the trustee is read-only, so no write operations are possible regardless of the\ngranted privileges or feature rights."
+          },
+          "tags": {
+            "type": "array",
+            "description": "The security tags assigned to the trustee.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TrusteeTag"
+            }
+          },
+          "auditMasks": {
+            "description": "The audit classes configured for the trustee, split into successful- and failed-operation\nmasks. Each map is keyed by audit-class name with the value indicating whether that class is\naudited.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrusteeAuditMasks"
+              }
+            ]
+          }
+        }
+      },
+      "TrusteeTag": {
+        "type": "object",
+        "description": "A security tag assigned to a trustee.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The tag's ID.",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "description": "The tag's name.",
+            "nullable": true
+          },
+          "isSecure": {
+            "type": "boolean",
+            "description": "True when the tag is a security tag."
+          }
+        }
+      },
+      "TrusteeAuditMasks": {
+        "type": "object",
+        "description": "The audit classes configured for a trustee, split by operation outcome.",
+        "additionalProperties": false,
+        "properties": {
+          "success": {
+            "type": "object",
+            "description": "Audit classes audited on successful operations, keyed by audit-class name.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "failure": {
+            "type": "object",
+            "description": "Audit classes audited on failed operations, keyed by audit-class name.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "boolean"
+            }
           }
         }
       }

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -3,7 +3,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Laserfiche Repository API",
-    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>1780117020_c895177fae051f04a31fdc4435df804fd4b8cde9</p>",
+    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>0.0.0.1</p>",
     "version": "2"
   },
   "servers": [
@@ -8380,6 +8380,359 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/AccessControl": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "summary": "- Returns the access control entries (ACEs) configured on the entry, both explicitly-set and inherited (inherited ACEs carry isInherited = true), plus whether the entry inherits rights from its parent(s).\n- Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.\n- The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetEntryAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The entry whose access control list is returned.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the entry's access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entry with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Entries"
+        ],
+        "summary": "- Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.\n- Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.\n- Each ACE is keyed by trustee.sid; trustee.accountName is optional and resolved server-side. A trustee that needs both allowed and denied rights is expressed as two ACEs.\n- The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.\n- Returns the entry's full ACL after the change.\n- Required OAuth scope: repository.Write",
+        "operationId": "SetEntryAccessControl",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The entry whose access control list is replaced.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The explicit access control entries to apply and, optionally, the parent-inheritance setting.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAccessControlRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the entry's access control list. Returned the updated access control list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessControlList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entry with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/EffectiveRights": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "summary": "- Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.\n- Pass trusteeId (a SID) to compute the effective rights for another trustee; omit it for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetEntryEffectiveRights",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The entry whose effective rights are computed.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "trusteeId",
+            "in": "query",
+            "description": "Optional. The SID of the trustee to compute effective rights for. When omitted, the effective rights of the current session are returned.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the effective rights for the entry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EffectiveRights"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entry with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories": {
       "get": {
         "tags": [
@@ -11568,6 +11921,123 @@
           }
         }
       }
+    },
+    "/v2/Repositories/{repositoryId}/Trustees": {
+      "get": {
+        "tags": [
+          "Trustees"
+        ],
+        "summary": "- Resolves trustee names to the SIDs used when building access control entries or reading effective rights for a trustee.\n- Each result includes the trustee's SID, account name, display name, type, whether it is a user or group, and whether the account is disabled.\n- Required OAuth scope: repository.Read",
+        "operationId": "LookupTrustees",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "The name (or name prefix) to search for.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Optional. Restrict the search to user or group trustees. When omitted, both users and groups are returned.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Optional. The maximum number of trustees to return. Defaults to 100.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the matching trustees.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrusteeIdentity"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -11590,6 +12060,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Attribute"
@@ -11695,6 +12166,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/AuditReason"
@@ -12040,6 +12512,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/FieldDefinition"
@@ -12529,6 +13002,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/LinkDefinition"
@@ -13655,6 +14129,7 @@
         "properties": {
           "value": {
             "type": "string",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true
           }
         }
@@ -13772,6 +14247,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Entry"
@@ -13797,6 +14273,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Field"
@@ -13837,6 +14314,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Tag"
@@ -13956,6 +14434,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Link"
@@ -14336,6 +14815,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/PageInfoResponse"
@@ -14521,55 +15001,11 @@
             "nullable": true
           },
           "extent": {
-            "description": "The lock extent. Defaults to All when omitted.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/LockExtent"
-              }
-            ]
+            "type": "string",
+            "description": "The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted.",
+            "nullable": true
           }
         }
-      },
-      "LockExtent": {
-        "type": "string",
-        "description": "The portion of a document that a persistent lock covers.",
-        "x-enum-names": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-varnames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enumNames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-descriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "x-enumDescriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "enum": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ]
       },
       "CheckOutDocumentRequest": {
         "type": "object",
@@ -14600,6 +15036,382 @@
           }
         }
       },
+      "AccessControlList": {
+        "type": "object",
+        "description": "An entry's access control list: the explicit and inherited access control entries plus\nwhether the entry inherits rights from its parent(s).",
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "The access control entries. Includes both explicitly-set and inherited ACEs;\ninherited ACEs carry isInherited = true.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AccessControlEntry"
+            }
+          },
+          "inheritParents": {
+            "type": "boolean",
+            "description": "Whether the entry inherits access rights from its parent(s). When false, the entry's\nACL is protected from parent inheritance."
+          }
+        }
+      },
+      "AccessControlEntry": {
+        "type": "object",
+        "description": "A single access control entry (ACE): one trustee, whether its rights are allowed or\ndenied, and the rights themselves. A trustee that has both allowed and denied rights is\nrepresented as two ACEs.",
+        "additionalProperties": false,
+        "properties": {
+          "trustee": {
+            "description": "The trustee this ACE applies to. On input, only trustee.sid is required.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TrusteeIdentity"
+              }
+            ]
+          },
+          "accessControlType": {
+            "description": "Whether the ACE grants (Allow) or denies (Deny) the listed rights.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AccessControlType"
+              }
+            ]
+          },
+          "rights": {
+            "type": "array",
+            "description": "The rights granted or denied by this ACE.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/EntryRight"
+            }
+          },
+          "scope": {
+            "description": "How the ACE propagates to descendant entries. Defaults to All when omitted on input.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EntryAccessScope"
+              }
+            ]
+          },
+          "isInherited": {
+            "type": "boolean",
+            "description": "True when this ACE is inherited from an ancestor. Read-only \u2014 inherited ACEs are\nreturned by GET but are ignored on input (the set operation manages explicit ACEs only)."
+          },
+          "inheritedFrom": {
+            "type": "string",
+            "description": "When inherited, a description of where the ACE was inherited from. Output only.",
+            "nullable": true
+          }
+        }
+      },
+      "TrusteeIdentity": {
+        "type": "object",
+        "description": "Identifies a security trustee (a user or a group) referenced by an access control\nentry, an effective-rights query, or a trustee-lookup result.",
+        "additionalProperties": false,
+        "properties": {
+          "sid": {
+            "type": "string",
+            "description": "The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is\nthe canonical, URL-safe id used to address a trustee when reading effective rights or\nbuilding access control entries.",
+            "nullable": true
+          },
+          "accountName": {
+            "type": "string",
+            "description": "The trustee's account name. Optional when supplied on input \u2014 it is resolved from the\nSID server-side. Always populated on output.",
+            "nullable": true
+          },
+          "trusteeType": {
+            "type": "string",
+            "description": "The trustee type: one of LaserficheUser, LaserficheGroup,\nWindowsAccount, LdapAccount, LfdsAccount.",
+            "nullable": true
+          },
+          "isUser": {
+            "type": "boolean",
+            "description": "True when the trustee is an individual user; false when it is a group."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "A human-readable display name. Populated by trustee-lookup results; omitted in\naccess-control-entry contexts.",
+            "nullable": true
+          },
+          "isDisabled": {
+            "type": "boolean",
+            "description": "True when the trustee account is disabled. Populated by trustee-lookup results."
+          }
+        }
+      },
+      "AccessControlType": {
+        "type": "string",
+        "description": "Whether an access control entry (ACE) grants or denies its rights. Serialized by name.",
+        "x-enum-names": [
+          "Allow",
+          "Deny"
+        ],
+        "x-enum-varnames": [
+          "Allow",
+          "Deny"
+        ],
+        "x-enumNames": [
+          "Allow",
+          "Deny"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null
+        ],
+        "enum": [
+          "Allow",
+          "Deny"
+        ]
+      },
+      "EntryRight": {
+        "type": "string",
+        "description": "An individual access right that can be granted to or denied a trustee on an entry.\nSerialized by name; emitted as a string enum in the OpenAPI schema so clients can\nreference it directly.",
+        "x-enum-names": [
+          "Browse",
+          "Read",
+          "WriteContent",
+          "AddPage",
+          "Rename",
+          "RemovePage",
+          "Freeze",
+          "Annotate",
+          "SeeThroughRedactions",
+          "SeeAnnotations",
+          "SetReviewDate",
+          "WriteMetadata",
+          "CreateFolder",
+          "CreateDocument",
+          "SetEventDate",
+          "Close",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enum-varnames": [
+          "Browse",
+          "Read",
+          "WriteContent",
+          "AddPage",
+          "Rename",
+          "RemovePage",
+          "Freeze",
+          "Annotate",
+          "SeeThroughRedactions",
+          "SeeAnnotations",
+          "SetReviewDate",
+          "WriteMetadata",
+          "CreateFolder",
+          "CreateDocument",
+          "SetEventDate",
+          "Close",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enumNames": [
+          "Browse",
+          "Read",
+          "WriteContent",
+          "AddPage",
+          "Rename",
+          "RemovePage",
+          "Freeze",
+          "Annotate",
+          "SeeThroughRedactions",
+          "SeeAnnotations",
+          "SetReviewDate",
+          "WriteMetadata",
+          "CreateFolder",
+          "CreateDocument",
+          "SetEventDate",
+          "Close",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Browse",
+          "Read",
+          "WriteContent",
+          "AddPage",
+          "Rename",
+          "RemovePage",
+          "Freeze",
+          "Annotate",
+          "SeeThroughRedactions",
+          "SeeAnnotations",
+          "SetReviewDate",
+          "WriteMetadata",
+          "CreateFolder",
+          "CreateDocument",
+          "SetEventDate",
+          "Close",
+          "Delete",
+          "ReadPermissions",
+          "ChangePermissions",
+          "TakeOwnership"
+        ]
+      },
+      "EntryAccessScope": {
+        "type": "string",
+        "description": "Controls how an entry access control entry (ACE) propagates to descendant entries.\nApplies to entry ACEs only (field/template ACEs have no scope). Serialized by name.",
+        "x-enum-names": [
+          "ThisEntry",
+          "Folders",
+          "All",
+          "NotThisEntry",
+          "FoldersOnly",
+          "DocumentsOnly",
+          "Immediate",
+          "ImmediateChildren",
+          "ImmediateDocuments"
+        ],
+        "x-enum-varnames": [
+          "ThisEntry",
+          "Folders",
+          "All",
+          "NotThisEntry",
+          "FoldersOnly",
+          "DocumentsOnly",
+          "Immediate",
+          "ImmediateChildren",
+          "ImmediateDocuments"
+        ],
+        "x-enumNames": [
+          "ThisEntry",
+          "Folders",
+          "All",
+          "NotThisEntry",
+          "FoldersOnly",
+          "DocumentsOnly",
+          "Immediate",
+          "ImmediateChildren",
+          "ImmediateDocuments"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "ThisEntry",
+          "Folders",
+          "All",
+          "NotThisEntry",
+          "FoldersOnly",
+          "DocumentsOnly",
+          "Immediate",
+          "ImmediateChildren",
+          "ImmediateDocuments"
+        ]
+      },
+      "SetAccessControlRequest": {
+        "type": "object",
+        "description": "Request body to replace an entry's explicit access control list. This is a full replace:\nthe supplied entries become the entry's complete set of explicit ACEs (any explicit ACE\nnot included is removed). Inherited ACEs cannot be supplied and are managed via\ninheritParents.",
+        "additionalProperties": false,
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "The explicit access control entries to apply. An empty array clears all explicit ACEs.\nEntries flagged isInherited = true are rejected.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AccessControlEntry"
+            }
+          },
+          "inheritParents": {
+            "type": "boolean",
+            "description": "Whether the entry should inherit access rights from its parent(s). When omitted, the\nentry's current inheritance setting is preserved. When false, the ACL is protected\nfrom parent inheritance; when true, parent rights are inherited.",
+            "nullable": true
+          }
+        }
+      },
+      "EffectiveRights": {
+        "type": "object",
+        "description": "A trustee's effective rights to an entry \u2014 the net rights after inheritance, group\nmembership, and allow/deny resolution are applied by the repository server.",
+        "additionalProperties": false,
+        "properties": {
+          "rights": {
+            "type": "array",
+            "description": "The rights effectively granted to the trustee on the entry.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/EntryRight"
+            }
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "True when the session is read-only, so no write operations are possible regardless of\nthe granted rights."
+          }
+        }
+      },
       "RepositoryCollectionResponse": {
         "type": "object",
         "description": "Response containing a collection of Repository.",
@@ -14607,6 +15419,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Repository"
@@ -14716,6 +15529,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/SearchContextHit"
@@ -14952,6 +15766,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TagDefinition"
@@ -15006,6 +15821,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TaskProgress"
@@ -15189,6 +16005,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/CancelTaskResult"
@@ -15238,6 +16055,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateDefinition"
@@ -15263,6 +16081,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateFieldDefinition"
@@ -15542,8 +16361,8 @@
         "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>https://api.laserfiche.com/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
         "flows": {
           "authorizationCode": {
-            "authorizationUrl": "https://signin.laserfiche.com/oauth/Authorize",
-            "tokenUrl": "https://signin.laserfiche.com/oauth/Token",
+            "authorizationUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Authorize",
+            "tokenUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Token",
             "scopes": {
               "repository.Read": "Allows the app to read the content of Laserfiche repositories on behalf of the signed-in user.",
               "repository.Write": "Allows the app to modify the content of Laserfiche repositories on behalf of the signed-in user."

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8385,7 +8385,7 @@
         "tags": [
           "Entries"
         ],
-        "summary": "- Returns the access control entries (ACEs) configured on the entry, both explicitly-set and inherited (inherited ACEs carry isInherited = true), plus whether the entry inherits rights from its parent(s).\n- Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.\n- The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.\n- Required OAuth scope: repository.Read",
+        "summary": "- Returns the access control entries (ACEs) configured on the entry \u2014 by default both explicitly-set and inherited (inherited ACEs carry isInherited = true), or only the explicit ones when includeInherited=false \u2014 plus whether the entry inherits rights from its parent(s).\n- Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.\n- The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.\n- Required OAuth scope: repository.Read",
         "operationId": "GetEntryAccessControl",
         "parameters": [
           {
@@ -8410,6 +8410,16 @@
             "x-position": 2
           },
           {
+            "name": "includeInherited",
+            "in": "query",
+            "description": "Optional. When true (the default), the response includes both the entry's explicit access control entries and the inherited ones (inherited ACEs carry isInherited = true). When false, only the explicit ACEs are returned \u2014 the exact set that the access-control PUT accepts \u2014 making it convenient to read, edit, and write back the ACL without filtering inherited entries client-side. The inheritParents flag is unaffected by this option.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            },
+            "x-position": 3
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Limits the properties returned in the result.",
@@ -8417,7 +8427,7 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 3
+            "x-position": 4
           }
         ],
         "responses": {
@@ -8609,13 +8619,13 @@
         }
       }
     },
-    "/v2/Repositories/{repositoryId}/Entries/{entryId}/EffectiveRights": {
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/Rights": {
       "get": {
         "tags": [
           "Entries"
         ],
-        "summary": "- Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.\n- Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
-        "operationId": "GetEntryEffectiveRights",
+        "summary": "- Returns the rights a trustee has on the entry. By default these are the effective rights \u2014 the same calculation the Laserfiche applications use, after allow/deny resolution, group membership, and the repository's privilege and records-management overlays. Set aclOnly=true to return only the rights granted by the entry's access control list (including its stored inherited ACEs) without the privilege/records-management overlays.\n- Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetEntryRights",
         "parameters": [
           {
             "name": "repositoryId",
@@ -8631,7 +8641,7 @@
             "name": "entryId",
             "in": "path",
             "required": true,
-            "description": "The entry whose effective rights are computed.",
+            "description": "The entry whose rights are computed.",
             "schema": {
               "type": "integer",
               "format": "int32"
@@ -8641,7 +8651,7 @@
           {
             "name": "trusteeId",
             "in": "query",
-            "description": "Optional. The SID of the trustee to compute effective rights for. When omitted (along with trusteeName), the effective rights of the current session are returned.",
+            "description": "Optional. The SID of the trustee to compute rights for. When omitted (along with trusteeName), the rights of the current session are returned.",
             "schema": {
               "type": "string",
               "nullable": true
@@ -8651,12 +8661,22 @@
           {
             "name": "trusteeName",
             "in": "query",
-            "description": "Optional. The account name of the trustee to compute effective rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.",
+            "description": "Optional. The account name of the trustee to compute rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.",
             "schema": {
               "type": "string",
               "nullable": true
             },
             "x-position": 4
+          },
+          {
+            "name": "aclOnly",
+            "in": "query",
+            "description": "Optional. Selects which rights are returned. Default (false): the trustee's effective rights \u2014 the net result after allow/deny resolution, group membership, and the repository's privilege and records-management overlays. When true: only the rights granted by this item's access control list \u2014 including inherited access control entries, which are stored on the item itself \u2014 without the privilege and records-management overlays (for example, a privilege that grants full control regardless of the ACL is reflected only when aclOnly=false). Group membership is always resolved. The aclOnly=true value is what the ACL editor displays as the net effect of the list.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 5
           },
           {
             "name": "$select",
@@ -8666,150 +8686,16 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 5
+            "x-position": 6
           }
         ],
         "responses": {
           "200": {
-            "description": "Successfully returned the effective rights for the entry.",
+            "description": "Successfully returned the rights for the entry.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EffectiveRights"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid or bad request.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Access token is invalid or expired.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Access denied for the operation.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Entry with requested ID was not found.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit is reached.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "An unexpected server-side error occurred.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/Repositories/{repositoryId}/Entries/{entryId}/DirectRights": {
-      "get": {
-        "tags": [
-          "Entries"
-        ],
-        "summary": "- Returns the rights granted by this entry's own ACL, excluding inheritance from parent folders and privilege/records-management overlays; group membership is still resolved. Contrast with EffectiveRights, which returns the net rights after inheritance and overlays are applied.\n- Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
-        "operationId": "GetEntryDirectRights",
-        "parameters": [
-          {
-            "name": "repositoryId",
-            "in": "path",
-            "required": true,
-            "description": "The requested repository ID.",
-            "schema": {
-              "type": "string"
-            },
-            "x-position": 1
-          },
-          {
-            "name": "entryId",
-            "in": "path",
-            "required": true,
-            "description": "The entry whose direct rights are computed.",
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "x-position": 2
-          },
-          {
-            "name": "trusteeId",
-            "in": "query",
-            "description": "Optional. The SID of the trustee to compute direct rights for. When omitted (along with trusteeName), the direct rights of the current session are returned.",
-            "schema": {
-              "type": "string",
-              "nullable": true
-            },
-            "x-position": 3
-          },
-          {
-            "name": "trusteeName",
-            "in": "query",
-            "description": "Optional. The account name of the trustee to compute direct rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.",
-            "schema": {
-              "type": "string",
-              "nullable": true
-            },
-            "x-position": 4
-          },
-          {
-            "name": "$select",
-            "in": "query",
-            "description": "Limits the properties returned in the result.",
-            "schema": {
-              "type": "string",
-              "nullable": true
-            },
-            "x-position": 5
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully returned the direct (ACL) rights for the entry.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EffectiveRights"
+                  "$ref": "#/components/schemas/EntryRights"
                 }
               }
             }
@@ -15537,14 +15423,14 @@
           }
         }
       },
-      "EffectiveRights": {
+      "EntryRights": {
         "type": "object",
-        "description": "A trustee's effective rights to an entry \u2014 the net rights after inheritance, group\nmembership, and allow/deny resolution are applied by the repository server.",
+        "description": "A trustee's rights to an entry. Depending on the aclOnly option on the request, these\nare either the effective rights (the net result after allow/deny resolution, group membership,\nand the repository's privilege and records-management overlays) or the rights granted by the\nentry's access control list alone.",
         "additionalProperties": false,
         "properties": {
           "rights": {
             "type": "array",
-            "description": "The rights effectively granted to the trustee on the entry.",
+            "description": "The rights granted to the trustee on the entry.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/EntryRight"

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8497,7 +8497,7 @@
         "tags": [
           "Entries"
         ],
-        "summary": "- Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.\n- Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.\n- Each ACE is keyed by trustee.sid; trustee.accountName is optional and resolved server-side. A trustee that needs both allowed and denied rights is expressed as two ACEs.\n- The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.\n- Returns the entry's full ACL after the change.\n- Required OAuth scope: repository.Write",
+        "summary": "- Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.\n- Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.\n- Each ACE identifies its trustee by trustee.sid or trustee.accountName (an account name is resolved to a SID server-side; the SID takes precedence when both are supplied). A trustee that needs both allowed and denied rights is expressed as two ACEs.\n- The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.\n- Returns the entry's full ACL after the change.\n- Required OAuth scope: repository.Write",
         "operationId": "SetEntryAccessControl",
         "parameters": [
           {
@@ -8614,7 +8614,7 @@
         "tags": [
           "Entries"
         ],
-        "summary": "- Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.\n- Pass trusteeId (a SID) to compute the effective rights for another trustee; omit it for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
+        "summary": "- Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.\n- Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
         "operationId": "GetEntryEffectiveRights",
         "parameters": [
           {
@@ -8641,12 +8641,22 @@
           {
             "name": "trusteeId",
             "in": "query",
-            "description": "Optional. The SID of the trustee to compute effective rights for. When omitted, the effective rights of the current session are returned.",
+            "description": "Optional. The SID of the trustee to compute effective rights for. When omitted (along with trusteeName), the effective rights of the current session are returned.",
             "schema": {
               "type": "string",
               "nullable": true
             },
             "x-position": 3
+          },
+          {
+            "name": "trusteeName",
+            "in": "query",
+            "description": "Optional. The account name of the trustee to compute effective rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
           },
           {
             "name": "$select",
@@ -8656,7 +8666,7 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           }
         ],
         "responses": {
@@ -15061,7 +15071,7 @@
         "additionalProperties": false,
         "properties": {
           "trustee": {
-            "description": "The trustee this ACE applies to. On input, only trustee.sid is required.",
+            "description": "The trustee this ACE applies to. On input, identify the trustee by either\ntrustee.sid or trustee.accountName (the SID takes precedence when both are given).",
             "nullable": true,
             "oneOf": [
               {
@@ -15111,12 +15121,12 @@
         "properties": {
           "sid": {
             "type": "string",
-            "description": "The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is\nthe canonical, URL-safe id used to address a trustee when reading effective rights or\nbuilding access control entries.",
+            "description": "The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is\nthe canonical, stable id for a trustee. On input it is preferred and takes precedence over\nAccountName; always populated on output.",
             "nullable": true
           },
           "accountName": {
             "type": "string",
-            "description": "The trustee's account name. Optional when supplied on input \u2014 it is resolved from the\nSID server-side. Always populated on output.",
+            "description": "The trustee's account name. On input it may be supplied instead of Sid to\naddress the trustee by name (resolved to a SID server-side); the SID wins when both are\ngiven. Always populated on output.",
             "nullable": true
           },
           "trusteeType": {
@@ -16358,7 +16368,7 @@
       },
       "OAuth2 Authorization Code Flow": {
         "type": "oauth2",
-        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>https://api.laserfiche.com/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
+        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>http://localhost:11211/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Authorize",

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8743,6 +8743,140 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/DirectRights": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "summary": "- Returns the rights granted by this entry's own ACL, excluding inheritance from parent folders and privilege/records-management overlays; group membership is still resolved. Contrast with EffectiveRights, which returns the net rights after inheritance and overlays are applied.\n- Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.\n- isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetEntryDirectRights",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The entry whose direct rights are computed.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "trusteeId",
+            "in": "query",
+            "description": "Optional. The SID of the trustee to compute direct rights for. When omitted (along with trusteeName), the direct rights of the current session are returned.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "trusteeName",
+            "in": "query",
+            "description": "Optional. The account name of the trustee to compute direct rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the direct (ACL) rights for the entry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EffectiveRights"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entry with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories": {
       "get": {
         "tags": [

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -2951,6 +2951,20 @@ export interface IEntriesClient {
      * @returns Successfully returned the effective rights for the entry.
      */
     getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
+
+    /**
+     * - Returns the rights granted by this entry's own ACL, excluding inheritance from parent folders and privilege/records-management overlays; group membership is still resolved. Contrast with EffectiveRights, which returns the net rights after inheritance and overlays are applied.
+    - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
+    - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose direct rights are computed.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute direct rights for. When omitted (along with trusteeName), the direct rights of the current session are returned.
+     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute direct rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the direct (ACL) rights for the entry.
+     */
+    getEntryDirectRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
 }
 
 export class EntriesClient implements IEntriesClient {
@@ -8230,6 +8244,107 @@ export class EntriesClient implements IEntriesClient {
     }
 
     protected processGetEntryEffectiveRights(response: Response): Promise<EffectiveRights> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = EffectiveRights.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Entry with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<EffectiveRights>(null as any);
+    }
+
+    /**
+     * - Returns the rights granted by this entry's own ACL, excluding inheritance from parent folders and privilege/records-management overlays; group membership is still resolved. Contrast with EffectiveRights, which returns the net rights after inheritance and overlays are applied.
+    - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
+    - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose direct rights are computed.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute direct rights for. When omitted (along with trusteeName), the direct rights of the current session are returned.
+     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute direct rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the direct (ACL) rights for the entry.
+     */
+    getEntryDirectRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights> {
+        let { repositoryId, entryId, trusteeId, trusteeName, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/DirectRights?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (trusteeId !== undefined && trusteeId !== null)
+            url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
+        if (trusteeName !== undefined && trusteeName !== null)
+            url_ += "trusteeName=" + encodeURIComponent("" + trusteeName) + "&";
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetEntryDirectRights(_response);
+        });
+    }
+
+    protected processGetEntryDirectRights(response: Response): Promise<EffectiveRights> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -2927,7 +2927,7 @@ export interface IEntriesClient {
     /**
      * - Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.
     - Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.
-    - Each ACE is keyed by trustee.sid; trustee.accountName is optional and resolved server-side. A trustee that needs both allowed and denied rights is expressed as two ACEs.
+    - Each ACE identifies its trustee by trustee.sid or trustee.accountName (an account name is resolved to a SID server-side; the SID takes precedence when both are supplied). A trustee that needs both allowed and denied rights is expressed as two ACEs.
     - The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.
     - Returns the entry's full ACL after the change.
     - Required OAuth scope: repository.Write
@@ -2940,16 +2940,17 @@ export interface IEntriesClient {
 
     /**
      * - Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.
-    - Pass trusteeId (a SID) to compute the effective rights for another trustee; omit it for the calling session.
+    - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
     - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
     - Required OAuth scope: repository.Read
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry whose effective rights are computed.
-     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted, the effective rights of the current session are returned.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted (along with trusteeName), the effective rights of the current session are returned.
+     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute effective rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the effective rights for the entry.
      */
-    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
+    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
 }
 
 export class EntriesClient implements IEntriesClient {
@@ -8091,7 +8092,7 @@ export class EntriesClient implements IEntriesClient {
     /**
      * - Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.
     - Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.
-    - Each ACE is keyed by trustee.sid; trustee.accountName is optional and resolved server-side. A trustee that needs both allowed and denied rights is expressed as two ACEs.
+    - Each ACE identifies its trustee by trustee.sid or trustee.accountName (an account name is resolved to a SID server-side; the SID takes precedence when both are supplied). A trustee that needs both allowed and denied rights is expressed as two ACEs.
     - The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.
     - Returns the entry's full ACL after the change.
     - Required OAuth scope: repository.Write
@@ -8189,17 +8190,18 @@ export class EntriesClient implements IEntriesClient {
 
     /**
      * - Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.
-    - Pass trusteeId (a SID) to compute the effective rights for another trustee; omit it for the calling session.
+    - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
     - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
     - Required OAuth scope: repository.Read
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry whose effective rights are computed.
-     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted, the effective rights of the current session are returned.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted (along with trusteeName), the effective rights of the current session are returned.
+     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute effective rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the effective rights for the entry.
      */
-    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights> {
-        let { repositoryId, entryId, trusteeId, select } = args;
+    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights> {
+        let { repositoryId, entryId, trusteeId, trusteeName, select } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/EffectiveRights?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -8209,6 +8211,8 @@ export class EntriesClient implements IEntriesClient {
         url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
         if (trusteeId !== undefined && trusteeId !== null)
             url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
+        if (trusteeName !== undefined && trusteeName !== null)
+            url_ += "trusteeName=" + encodeURIComponent("" + trusteeName) + "&";
         if (select !== undefined && select !== null)
             url_ += "$select=" + encodeURIComponent("" + select) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -17169,7 +17173,8 @@ ACL is protected from parent inheritance. */
 
 /** A single access control entry (ACE): one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. */
 export class AccessControlEntry implements IAccessControlEntry {
-    /** The trustee this ACE applies to. On input, only trustee.sid is required. */
+    /** The trustee this ACE applies to. On input, identify the trustee by either
+trustee.sid or trustee.accountName (the SID takes precedence when both are given). */
     trustee?: TrusteeIdentity | undefined;
     /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. */
     accessControlType?: AccessControlType;
@@ -17234,7 +17239,8 @@ returned by GET but are ignored on input (the set operation manages explicit ACE
 
 /** A single access control entry (ACE): one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. */
 export interface IAccessControlEntry {
-    /** The trustee this ACE applies to. On input, only trustee.sid is required. */
+    /** The trustee this ACE applies to. On input, identify the trustee by either
+trustee.sid or trustee.accountName (the SID takes precedence when both are given). */
     trustee?: TrusteeIdentity | undefined;
     /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. */
     accessControlType?: AccessControlType;
@@ -17252,11 +17258,12 @@ returned by GET but are ignored on input (the set operation manages explicit ACE
 /** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
 export class TrusteeIdentity implements ITrusteeIdentity {
     /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
-the canonical, URL-safe id used to address a trustee when reading effective rights or
-building access control entries. */
+the canonical, stable id for a trustee. On input it is preferred and takes precedence over
+AccountName; always populated on output. */
     sid?: string | undefined;
-    /** The trustee's account name. Optional when supplied on input — it is resolved from the
-SID server-side. Always populated on output. */
+    /** The trustee's account name. On input it may be supplied instead of Sid to
+address the trustee by name (resolved to a SID server-side); the SID wins when both are
+given. Always populated on output. */
     accountName?: string | undefined;
     /** The trustee type: one of LaserficheUser, LaserficheGroup,
 WindowsAccount, LdapAccount, LfdsAccount. */
@@ -17313,11 +17320,12 @@ access-control-entry contexts. */
 /** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
 export interface ITrusteeIdentity {
     /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
-the canonical, URL-safe id used to address a trustee when reading effective rights or
-building access control entries. */
+the canonical, stable id for a trustee. On input it is preferred and takes precedence over
+AccountName; always populated on output. */
     sid?: string | undefined;
-    /** The trustee's account name. Optional when supplied on input — it is resolved from the
-SID server-side. Always populated on output. */
+    /** The trustee's account name. On input it may be supplied instead of Sid to
+address the trustee by name (resolved to a SID server-side); the SID wins when both are
+given. Always populated on output. */
     accountName?: string | undefined;
     /** The trustee type: one of LaserficheUser, LaserficheGroup,
 WindowsAccount, LdapAccount, LfdsAccount. */
@@ -19124,6 +19132,7 @@ export interface IRepositoryApiClient {
   tasksClient: ITasksClient;
   templateDefinitionsClient: ITemplateDefinitionsClient;
   linkDefinitionsClient: ILinkDefinitionsClient;
+  trusteesClient: ITrusteesClient;
   defaultRequestHeaders: Record<string, string>;
 }
 
@@ -19142,6 +19151,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
   public tasksClient: ITasksClient;
   public templateDefinitionsClient: ITemplateDefinitionsClient;
   public linkDefinitionsClient: ILinkDefinitionsClient;
+  public trusteesClient: ITrusteesClient;
 
   private repoClientHandler: RepositoryApiClientHttpHandler;
 
@@ -19181,6 +19191,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
     this.tasksClient = new TasksClient(this.baseUrl, http);
     this.templateDefinitionsClient = new TemplateDefinitionsClient(this.baseUrl, http);
     this.linkDefinitionsClient = new LinkDefinitionsClient(this.baseUrl, http);
+    this.trusteesClient = new TrusteesClient(this.baseUrl, http);
   }
 
   /**

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -2911,6 +2911,45 @@ export interface IEntriesClient {
      * @returns Successfully undid the document check-out. Any persistent lock held on the document has been released.
      */
     undoCheckOut(args: { repositoryId: string, entryId: number }): Promise<Entry>;
+
+    /**
+     * - Returns the access control entries (ACEs) configured on the entry, both explicitly-set and inherited (inherited ACEs carry isInherited = true), plus whether the entry inherits rights from its parent(s).
+    - Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.
+    - The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose access control list is returned.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the entry's access control list.
+     */
+    getEntryAccessControl(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AccessControlList>;
+
+    /**
+     * - Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.
+    - Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.
+    - Each ACE is keyed by trustee.sid; trustee.accountName is optional and resolved server-side. A trustee that needs both allowed and denied rights is expressed as two ACEs.
+    - The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.
+    - Returns the entry's full ACL after the change.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose access control list is replaced.
+     * @param args.request The explicit access control entries to apply and, optionally, the parent-inheritance setting.
+     * @returns Successfully replaced the entry's access control list. Returned the updated access control list.
+     */
+    setEntryAccessControl(args: { repositoryId: string, entryId: number, request: SetAccessControlRequest }): Promise<AccessControlList>;
+
+    /**
+     * - Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.
+    - Pass trusteeId (a SID) to compute the effective rights for another trustee; omit it for the calling session.
+    - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose effective rights are computed.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted, the effective rights of the current session are returned.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the effective rights for the entry.
+     */
+    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
 }
 
 export class EntriesClient implements IEntriesClient {
@@ -7953,6 +7992,298 @@ export class EntriesClient implements IEntriesClient {
         }
         return Promise.resolve<Entry>(null as any);
     }
+
+    /**
+     * - Returns the access control entries (ACEs) configured on the entry, both explicitly-set and inherited (inherited ACEs carry isInherited = true), plus whether the entry inherits rights from its parent(s).
+    - Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.
+    - The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose access control list is returned.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the entry's access control list.
+     */
+    getEntryAccessControl(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AccessControlList> {
+        let { repositoryId, entryId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/AccessControl?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetEntryAccessControl(_response);
+        });
+    }
+
+    protected processGetEntryAccessControl(response: Response): Promise<AccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Entry with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AccessControlList>(null as any);
+    }
+
+    /**
+     * - Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.
+    - Inherited ACEs cannot be supplied (entries flagged isInherited = true are rejected with 400); inheritance is controlled via inheritParents. When inheritParents is omitted, the entry's current inheritance setting is preserved.
+    - Each ACE is keyed by trustee.sid; trustee.accountName is optional and resolved server-side. A trustee that needs both allowed and denied rights is expressed as two ACEs.
+    - The repository session enforces the underlying permission: changing an ACL requires the ChangePermissions right on the entry, and a 403 is returned when it is lacking. The repository.Write OAuth scope is necessary but not sufficient.
+    - Returns the entry's full ACL after the change.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose access control list is replaced.
+     * @param args.request The explicit access control entries to apply and, optionally, the parent-inheritance setting.
+     * @returns Successfully replaced the entry's access control list. Returned the updated access control list.
+     */
+    setEntryAccessControl(args: { repositoryId: string, entryId: number, request: SetAccessControlRequest }): Promise<AccessControlList> {
+        let { repositoryId, entryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/AccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetEntryAccessControl(_response);
+        });
+    }
+
+    protected processSetEntryAccessControl(response: Response): Promise<AccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Entry with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AccessControlList>(null as any);
+    }
+
+    /**
+     * - Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.
+    - Pass trusteeId (a SID) to compute the effective rights for another trustee; omit it for the calling session.
+    - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The entry whose effective rights are computed.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted, the effective rights of the current session are returned.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the effective rights for the entry.
+     */
+    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights> {
+        let { repositoryId, entryId, trusteeId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/EffectiveRights?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (trusteeId !== undefined && trusteeId !== null)
+            url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetEntryEffectiveRights(_response);
+        });
+    }
+
+    protected processGetEntryEffectiveRights(response: Response): Promise<EffectiveRights> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = EffectiveRights.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Entry with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<EffectiveRights>(null as any);
+    }
 }
 
 export interface IRepositoriesClient {
@@ -11340,12 +11671,137 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
     }
 }
 
+export interface ITrusteesClient {
+
+    /**
+     * - Resolves trustee names to the SIDs used when building access control entries or reading effective rights for a trustee.
+    - Each result includes the trustee's SID, account name, display name, type, whether it is a user or group, and whether the account is disabled.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.search (optional) The name (or name prefix) to search for.
+     * @param args.type (optional) Optional. Restrict the search to user or group trustees. When omitted, both users and groups are returned.
+     * @param args.count (optional) Optional. The maximum number of trustees to return. Defaults to 100.
+     * @returns Successfully returned the matching trustees.
+     */
+    lookupTrustees(args: { repositoryId: string, search?: string | null | undefined, type?: string | null | undefined, count?: number | undefined }): Promise<TrusteeIdentity[]>;
+}
+
+export class TrusteesClient implements ITrusteesClient {
+    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : window as any;
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+    }
+
+    /**
+     * - Resolves trustee names to the SIDs used when building access control entries or reading effective rights for a trustee.
+    - Each result includes the trustee's SID, account name, display name, type, whether it is a user or group, and whether the account is disabled.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.search (optional) The name (or name prefix) to search for.
+     * @param args.type (optional) Optional. Restrict the search to user or group trustees. When omitted, both users and groups are returned.
+     * @param args.count (optional) Optional. The maximum number of trustees to return. Defaults to 100.
+     * @returns Successfully returned the matching trustees.
+     */
+    lookupTrustees(args: { repositoryId: string, search?: string | null | undefined, type?: string | null | undefined, count?: number | undefined }): Promise<TrusteeIdentity[]> {
+        let { repositoryId, search, type, count } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Trustees?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (search !== undefined && search !== null)
+            url_ += "search=" + encodeURIComponent("" + search) + "&";
+        if (type !== undefined && type !== null)
+            url_ += "type=" + encodeURIComponent("" + type) + "&";
+        if (count === null)
+            throw new Error("The parameter 'count' cannot be null.");
+        else if (count !== undefined)
+            url_ += "count=" + encodeURIComponent("" + count) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processLookupTrustees(_response);
+        });
+    }
+
+    protected processLookupTrustees(response: Response): Promise<TrusteeIdentity[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(TrusteeIdentity.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TrusteeIdentity[]>(null as any);
+    }
+}
+
 /** Response containing a collection of Attribute. */
 export class AttributeCollectionResponse implements IAttributeCollectionResponse {
     /** A URL to retrieve the next page of the requested collection. */
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Attribute[] | undefined;
 
     
@@ -11397,6 +11853,7 @@ export interface IAttributeCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Attribute[] | undefined;
 }
 
@@ -11564,6 +12021,7 @@ export class AuditReasonCollectionResponse implements IAuditReasonCollectionResp
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: AuditReason[] | undefined;
 
     
@@ -11615,6 +12073,7 @@ export interface IAuditReasonCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: AuditReason[] | undefined;
 }
 
@@ -11879,6 +12338,7 @@ export class FieldDefinitionCollectionResponse implements IFieldDefinitionCollec
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
 
     
@@ -11930,6 +12390,7 @@ export interface IFieldDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
 }
 
@@ -12852,6 +13313,7 @@ export class LinkDefinitionCollectionResponse implements ILinkDefinitionCollecti
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: LinkDefinition[] | undefined;
 
     
@@ -12903,6 +13365,7 @@ export interface ILinkDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: LinkDefinition[] | undefined;
 }
 
@@ -14696,6 +15159,7 @@ Does not affect pages generated from `file` — use `pdfOptions.generateText` fo
 
 /** Response containing a link to download the exported entry. */
 export class ExportEntryResponse implements IExportEntryResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: string | undefined;
 
     
@@ -14731,6 +15195,7 @@ export class ExportEntryResponse implements IExportEntryResponse {
 
 /** Response containing a link to download the exported entry. */
 export interface IExportEntryResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: string | undefined;
 }
 
@@ -14914,6 +15379,7 @@ export class EntryCollectionResponse implements IEntryCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Entry[] | undefined;
 
     
@@ -14965,6 +15431,7 @@ export interface IEntryCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Entry[] | undefined;
 }
 
@@ -14974,6 +15441,7 @@ export class FieldCollectionResponse implements IFieldCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Field[] | undefined;
 
     
@@ -15025,6 +15493,7 @@ export interface IFieldCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Field[] | undefined;
 }
 
@@ -15084,6 +15553,7 @@ export class TagCollectionResponse implements ITagCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Tag[] | undefined;
 
     
@@ -15135,6 +15605,7 @@ export interface ITagCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Tag[] | undefined;
 }
 
@@ -15338,6 +15809,7 @@ export class LinkCollectionResponse implements ILinkCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Link[] | undefined;
 
     
@@ -15389,6 +15861,7 @@ export interface ILinkCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Link[] | undefined;
 }
 
@@ -16098,6 +16571,7 @@ export class PageInfoCollectionResponse implements IPageInfoCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: PageInfoResponse[] | undefined;
 
     
@@ -16149,6 +16623,7 @@ export interface IPageInfoCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: PageInfoResponse[] | undefined;
 }
 
@@ -16492,8 +16967,8 @@ Account renames change this value over time — do not use for stable identity c
 export class LockDocumentRequest implements ILockDocumentRequest {
     /** An optional comment for the persistent lock. */
     comment?: string | undefined;
-    /** The lock extent. Defaults to All when omitted. */
-    extent?: LockExtent | undefined;
+    /** The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted. */
+    extent?: string | undefined;
 
     
     
@@ -16532,16 +17007,8 @@ export class LockDocumentRequest implements ILockDocumentRequest {
 export interface ILockDocumentRequest {
     /** An optional comment for the persistent lock. */
     comment?: string | undefined;
-    /** The lock extent. Defaults to All when omitted. */
-    extent?: LockExtent | undefined;
-}
-
-/** The portion of a document that a persistent lock covers. */
-export enum LockExtent {
-    Page = "Page",
-    Edoc = "Edoc",
-    Metadata = "Metadata",
-    All = "All",
+    /** The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted. */
+    extent?: string | undefined;
 }
 
 /** Request body for checking out a document. */
@@ -16640,8 +17107,396 @@ export interface ICheckInDocumentRequest {
     unlock?: boolean;
 }
 
+/** An entry's access control list: the explicit and inherited access control entries plus whether the entry inherits rights from its parent(s). */
+export class AccessControlList implements IAccessControlList {
+    /** The access control entries. Includes both explicitly-set and inherited ACEs;
+inherited ACEs carry isInherited = true. */
+    entries?: AccessControlEntry[] | undefined;
+    /** Whether the entry inherits access rights from its parent(s). When false, the entry's
+ACL is protected from parent inheritance. */
+    inheritParents?: boolean;
+
+    
+    
+    constructor(data?: IAccessControlList) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entries"])) {
+                this.entries = [] as any;
+                for (let item of _data["entries"])
+                    this.entries!.push(AccessControlEntry.fromJS(item));
+            }
+            this.inheritParents = _data["inheritParents"];
+        }
+    }
+
+    static fromJS(data: any): AccessControlList {
+        data = typeof data === 'object' ? data : {};
+        let result = new AccessControlList();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entries)) {
+            data["entries"] = [];
+            for (let item of this.entries)
+                data["entries"].push(item.toJSON());
+        }
+        data["inheritParents"] = this.inheritParents;
+        return data;
+    }
+}
+
+/** An entry's access control list: the explicit and inherited access control entries plus whether the entry inherits rights from its parent(s). */
+export interface IAccessControlList {
+    /** The access control entries. Includes both explicitly-set and inherited ACEs;
+inherited ACEs carry isInherited = true. */
+    entries?: AccessControlEntry[] | undefined;
+    /** Whether the entry inherits access rights from its parent(s). When false, the entry's
+ACL is protected from parent inheritance. */
+    inheritParents?: boolean;
+}
+
+/** A single access control entry (ACE): one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. */
+export class AccessControlEntry implements IAccessControlEntry {
+    /** The trustee this ACE applies to. On input, only trustee.sid is required. */
+    trustee?: TrusteeIdentity | undefined;
+    /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. */
+    accessControlType?: AccessControlType;
+    /** The rights granted or denied by this ACE. */
+    rights?: EntryRight[] | undefined;
+    /** How the ACE propagates to descendant entries. Defaults to All when omitted on input. */
+    scope?: EntryAccessScope;
+    /** True when this ACE is inherited from an ancestor. Read-only — inherited ACEs are
+returned by GET but are ignored on input (the set operation manages explicit ACEs only). */
+    isInherited?: boolean;
+    /** When inherited, a description of where the ACE was inherited from. Output only. */
+    inheritedFrom?: string | undefined;
+
+    
+    
+    constructor(data?: IAccessControlEntry) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.trustee = _data["trustee"] ? TrusteeIdentity.fromJS(_data["trustee"]) : <any>undefined;
+            this.accessControlType = _data["accessControlType"];
+            if (Array.isArray(_data["rights"])) {
+                this.rights = [] as any;
+                for (let item of _data["rights"])
+                    this.rights!.push(item);
+            }
+            this.scope = _data["scope"];
+            this.isInherited = _data["isInherited"];
+            this.inheritedFrom = _data["inheritedFrom"];
+        }
+    }
+
+    static fromJS(data: any): AccessControlEntry {
+        data = typeof data === 'object' ? data : {};
+        let result = new AccessControlEntry();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["trustee"] = this.trustee ? this.trustee.toJSON() : <any>undefined;
+        data["accessControlType"] = this.accessControlType;
+        if (Array.isArray(this.rights)) {
+            data["rights"] = [];
+            for (let item of this.rights)
+                data["rights"].push(item);
+        }
+        data["scope"] = this.scope;
+        data["isInherited"] = this.isInherited;
+        data["inheritedFrom"] = this.inheritedFrom;
+        return data;
+    }
+}
+
+/** A single access control entry (ACE): one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. */
+export interface IAccessControlEntry {
+    /** The trustee this ACE applies to. On input, only trustee.sid is required. */
+    trustee?: TrusteeIdentity | undefined;
+    /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. */
+    accessControlType?: AccessControlType;
+    /** The rights granted or denied by this ACE. */
+    rights?: EntryRight[] | undefined;
+    /** How the ACE propagates to descendant entries. Defaults to All when omitted on input. */
+    scope?: EntryAccessScope;
+    /** True when this ACE is inherited from an ancestor. Read-only — inherited ACEs are
+returned by GET but are ignored on input (the set operation manages explicit ACEs only). */
+    isInherited?: boolean;
+    /** When inherited, a description of where the ACE was inherited from. Output only. */
+    inheritedFrom?: string | undefined;
+}
+
+/** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
+export class TrusteeIdentity implements ITrusteeIdentity {
+    /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
+the canonical, URL-safe id used to address a trustee when reading effective rights or
+building access control entries. */
+    sid?: string | undefined;
+    /** The trustee's account name. Optional when supplied on input — it is resolved from the
+SID server-side. Always populated on output. */
+    accountName?: string | undefined;
+    /** The trustee type: one of LaserficheUser, LaserficheGroup,
+WindowsAccount, LdapAccount, LfdsAccount. */
+    trusteeType?: string | undefined;
+    /** True when the trustee is an individual user; false when it is a group. */
+    isUser?: boolean;
+    /** A human-readable display name. Populated by trustee-lookup results; omitted in
+access-control-entry contexts. */
+    displayName?: string | undefined;
+    /** True when the trustee account is disabled. Populated by trustee-lookup results. */
+    isDisabled?: boolean;
+
+    
+    
+    constructor(data?: ITrusteeIdentity) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.sid = _data["sid"];
+            this.accountName = _data["accountName"];
+            this.trusteeType = _data["trusteeType"];
+            this.isUser = _data["isUser"];
+            this.displayName = _data["displayName"];
+            this.isDisabled = _data["isDisabled"];
+        }
+    }
+
+    static fromJS(data: any): TrusteeIdentity {
+        data = typeof data === 'object' ? data : {};
+        let result = new TrusteeIdentity();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["sid"] = this.sid;
+        data["accountName"] = this.accountName;
+        data["trusteeType"] = this.trusteeType;
+        data["isUser"] = this.isUser;
+        data["displayName"] = this.displayName;
+        data["isDisabled"] = this.isDisabled;
+        return data;
+    }
+}
+
+/** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
+export interface ITrusteeIdentity {
+    /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
+the canonical, URL-safe id used to address a trustee when reading effective rights or
+building access control entries. */
+    sid?: string | undefined;
+    /** The trustee's account name. Optional when supplied on input — it is resolved from the
+SID server-side. Always populated on output. */
+    accountName?: string | undefined;
+    /** The trustee type: one of LaserficheUser, LaserficheGroup,
+WindowsAccount, LdapAccount, LfdsAccount. */
+    trusteeType?: string | undefined;
+    /** True when the trustee is an individual user; false when it is a group. */
+    isUser?: boolean;
+    /** A human-readable display name. Populated by trustee-lookup results; omitted in
+access-control-entry contexts. */
+    displayName?: string | undefined;
+    /** True when the trustee account is disabled. Populated by trustee-lookup results. */
+    isDisabled?: boolean;
+}
+
+/** Whether an access control entry (ACE) grants or denies its rights. Serialized by name. */
+export enum AccessControlType {
+    Allow = "Allow",
+    Deny = "Deny",
+}
+
+/** An individual access right that can be granted to or denied a trustee on an entry. Serialized by name; emitted as a string enum in the OpenAPI schema so clients can reference it directly. */
+export enum EntryRight {
+    Browse = "Browse",
+    Read = "Read",
+    WriteContent = "WriteContent",
+    AddPage = "AddPage",
+    Rename = "Rename",
+    RemovePage = "RemovePage",
+    Freeze = "Freeze",
+    Annotate = "Annotate",
+    SeeThroughRedactions = "SeeThroughRedactions",
+    SeeAnnotations = "SeeAnnotations",
+    SetReviewDate = "SetReviewDate",
+    WriteMetadata = "WriteMetadata",
+    CreateFolder = "CreateFolder",
+    CreateDocument = "CreateDocument",
+    SetEventDate = "SetEventDate",
+    Close = "Close",
+    Delete = "Delete",
+    ReadPermissions = "ReadPermissions",
+    ChangePermissions = "ChangePermissions",
+    TakeOwnership = "TakeOwnership",
+}
+
+/** Controls how an entry access control entry (ACE) propagates to descendant entries. Applies to entry ACEs only (field/template ACEs have no scope). Serialized by name. */
+export enum EntryAccessScope {
+    ThisEntry = "ThisEntry",
+    Folders = "Folders",
+    All = "All",
+    NotThisEntry = "NotThisEntry",
+    FoldersOnly = "FoldersOnly",
+    DocumentsOnly = "DocumentsOnly",
+    Immediate = "Immediate",
+    ImmediateChildren = "ImmediateChildren",
+    ImmediateDocuments = "ImmediateDocuments",
+}
+
+/** Request body to replace an entry's explicit access control list. This is a full replace: the supplied entries become the entry's complete set of explicit ACEs (any explicit ACE not included is removed). Inherited ACEs cannot be supplied and are managed via inheritParents. */
+export class SetAccessControlRequest implements ISetAccessControlRequest {
+    /** The explicit access control entries to apply. An empty array clears all explicit ACEs.
+Entries flagged isInherited = true are rejected. */
+    entries?: AccessControlEntry[] | undefined;
+    /** Whether the entry should inherit access rights from its parent(s). When omitted, the
+entry's current inheritance setting is preserved. When false, the ACL is protected
+from parent inheritance; when true, parent rights are inherited. */
+    inheritParents?: boolean | undefined;
+
+    
+    
+    constructor(data?: ISetAccessControlRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entries"])) {
+                this.entries = [] as any;
+                for (let item of _data["entries"])
+                    this.entries!.push(AccessControlEntry.fromJS(item));
+            }
+            this.inheritParents = _data["inheritParents"];
+        }
+    }
+
+    static fromJS(data: any): SetAccessControlRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new SetAccessControlRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entries)) {
+            data["entries"] = [];
+            for (let item of this.entries)
+                data["entries"].push(item.toJSON());
+        }
+        data["inheritParents"] = this.inheritParents;
+        return data;
+    }
+}
+
+/** Request body to replace an entry's explicit access control list. This is a full replace: the supplied entries become the entry's complete set of explicit ACEs (any explicit ACE not included is removed). Inherited ACEs cannot be supplied and are managed via inheritParents. */
+export interface ISetAccessControlRequest {
+    /** The explicit access control entries to apply. An empty array clears all explicit ACEs.
+Entries flagged isInherited = true are rejected. */
+    entries?: AccessControlEntry[] | undefined;
+    /** Whether the entry should inherit access rights from its parent(s). When omitted, the
+entry's current inheritance setting is preserved. When false, the ACL is protected
+from parent inheritance; when true, parent rights are inherited. */
+    inheritParents?: boolean | undefined;
+}
+
+/** A trustee's effective rights to an entry — the net rights after inheritance, group membership, and allow/deny resolution are applied by the repository server. */
+export class EffectiveRights implements IEffectiveRights {
+    /** The rights effectively granted to the trustee on the entry. */
+    rights?: EntryRight[] | undefined;
+    /** True when the session is read-only, so no write operations are possible regardless of
+the granted rights. */
+    isReadOnly?: boolean;
+
+    
+    
+    constructor(data?: IEffectiveRights) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["rights"])) {
+                this.rights = [] as any;
+                for (let item of _data["rights"])
+                    this.rights!.push(item);
+            }
+            this.isReadOnly = _data["isReadOnly"];
+        }
+    }
+
+    static fromJS(data: any): EffectiveRights {
+        data = typeof data === 'object' ? data : {};
+        let result = new EffectiveRights();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.rights)) {
+            data["rights"] = [];
+            for (let item of this.rights)
+                data["rights"].push(item);
+        }
+        data["isReadOnly"] = this.isReadOnly;
+        return data;
+    }
+}
+
+/** A trustee's effective rights to an entry — the net rights after inheritance, group membership, and allow/deny resolution are applied by the repository server. */
+export interface IEffectiveRights {
+    /** The rights effectively granted to the trustee on the entry. */
+    rights?: EntryRight[] | undefined;
+    /** True when the session is read-only, so no write operations are possible regardless of
+the granted rights. */
+    isReadOnly?: boolean;
+}
+
 /** Response containing a collection of Repository. */
 export class RepositoryCollectionResponse implements IRepositoryCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: Repository[] | undefined;
 
     
@@ -16685,6 +17540,7 @@ export class RepositoryCollectionResponse implements IRepositoryCollectionRespon
 
 /** Response containing a collection of Repository. */
 export interface IRepositoryCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: Repository[] | undefined;
 }
 
@@ -16808,6 +17664,7 @@ export class SearchContextHitCollectionResponse implements ISearchContextHitColl
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: SearchContextHit[] | undefined;
 
     
@@ -16859,6 +17716,7 @@ export interface ISearchContextHitCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: SearchContextHit[] | undefined;
 }
 
@@ -17056,6 +17914,7 @@ export class TagDefinitionCollectionResponse implements ITagDefinitionCollection
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TagDefinition[] | undefined;
 
     
@@ -17107,6 +17966,7 @@ export interface ITagDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TagDefinition[] | undefined;
 }
 
@@ -17184,6 +18044,7 @@ export interface ITagDefinition {
 
 /** Response containing a collection of TaskProgress. */
 export class TaskCollectionResponse implements ITaskCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: TaskProgress[] | undefined;
 
     
@@ -17227,6 +18088,7 @@ export class TaskCollectionResponse implements ITaskCollectionResponse {
 
 /** Response containing a collection of TaskProgress. */
 export interface ITaskCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: TaskProgress[] | undefined;
 }
 
@@ -17390,6 +18252,7 @@ export interface ITaskResult {
 
 /** Response containing a collection of CancelTaskResult. */
 export class CancelTasksResponse implements ICancelTasksResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: CancelTaskResult[] | undefined;
 
     
@@ -17433,6 +18296,7 @@ export class CancelTasksResponse implements ICancelTasksResponse {
 
 /** Response containing a collection of CancelTaskResult. */
 export interface ICancelTasksResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: CancelTaskResult[] | undefined;
 }
 
@@ -17496,6 +18360,7 @@ export class TemplateDefinitionCollectionResponse implements ITemplateDefinition
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
 
     
@@ -17547,6 +18412,7 @@ export interface ITemplateDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
 }
 
@@ -17556,6 +18422,7 @@ export class TemplateFieldDefinitionCollectionResponse implements ITemplateField
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateFieldDefinition[] | undefined;
 
     
@@ -17607,6 +18474,7 @@ export interface ITemplateFieldDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateFieldDefinition[] | undefined;
 }
 

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -2913,16 +2913,17 @@ export interface IEntriesClient {
     undoCheckOut(args: { repositoryId: string, entryId: number }): Promise<Entry>;
 
     /**
-     * - Returns the access control entries (ACEs) configured on the entry, both explicitly-set and inherited (inherited ACEs carry isInherited = true), plus whether the entry inherits rights from its parent(s).
+     * - Returns the access control entries (ACEs) configured on the entry — by default both explicitly-set and inherited (inherited ACEs carry isInherited = true), or only the explicit ones when includeInherited=false — plus whether the entry inherits rights from its parent(s).
     - Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.
     - The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.
     - Required OAuth scope: repository.Read
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry whose access control list is returned.
+     * @param args.includeInherited (optional) Optional. When true (the default), the response includes both the entry's explicit access control entries and the inherited ones (inherited ACEs carry isInherited = true). When false, only the explicit ACEs are returned — the exact set that the access-control PUT accepts — making it convenient to read, edit, and write back the ACL without filtering inherited entries client-side. The inheritParents flag is unaffected by this option.
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the entry's access control list.
      */
-    getEntryAccessControl(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AccessControlList>;
+    getEntryAccessControl(args: { repositoryId: string, entryId: number, includeInherited?: boolean | undefined, select?: string | null | undefined }): Promise<AccessControlList>;
 
     /**
      * - Full replace of the entry's explicit ACEs: the supplied entries become the entry's complete set of explicit ACEs, and any explicit ACE not included is removed. An empty entries array clears all explicit ACEs.
@@ -2939,32 +2940,19 @@ export interface IEntriesClient {
     setEntryAccessControl(args: { repositoryId: string, entryId: number, request: SetAccessControlRequest }): Promise<AccessControlList>;
 
     /**
-     * - Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.
+     * - Returns the rights a trustee has on the entry. By default these are the effective rights — the same calculation the Laserfiche applications use, after allow/deny resolution, group membership, and the repository's privilege and records-management overlays. Set aclOnly=true to return only the rights granted by the entry's access control list (including its stored inherited ACEs) without the privilege/records-management overlays.
     - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
     - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
     - Required OAuth scope: repository.Read
      * @param args.repositoryId The requested repository ID.
-     * @param args.entryId The entry whose effective rights are computed.
-     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted (along with trusteeName), the effective rights of the current session are returned.
-     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute effective rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
+     * @param args.entryId The entry whose rights are computed.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute rights for. When omitted (along with trusteeName), the rights of the current session are returned.
+     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
+     * @param args.aclOnly (optional) Optional. Selects which rights are returned. Default (false): the trustee's effective rights — the net result after allow/deny resolution, group membership, and the repository's privilege and records-management overlays. When true: only the rights granted by this item's access control list — including inherited access control entries, which are stored on the item itself — without the privilege and records-management overlays (for example, a privilege that grants full control regardless of the ACL is reflected only when aclOnly=false). Group membership is always resolved. The aclOnly=true value is what the ACL editor displays as the net effect of the list.
      * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the effective rights for the entry.
+     * @returns Successfully returned the rights for the entry.
      */
-    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
-
-    /**
-     * - Returns the rights granted by this entry's own ACL, excluding inheritance from parent folders and privilege/records-management overlays; group membership is still resolved. Contrast with EffectiveRights, which returns the net rights after inheritance and overlays are applied.
-    - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
-    - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
-    - Required OAuth scope: repository.Read
-     * @param args.repositoryId The requested repository ID.
-     * @param args.entryId The entry whose direct rights are computed.
-     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute direct rights for. When omitted (along with trusteeName), the direct rights of the current session are returned.
-     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute direct rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the direct (ACL) rights for the entry.
-     */
-    getEntryDirectRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights>;
+    getEntryRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, aclOnly?: boolean | undefined, select?: string | null | undefined }): Promise<EntryRights>;
 }
 
 export class EntriesClient implements IEntriesClient {
@@ -8009,17 +7997,18 @@ export class EntriesClient implements IEntriesClient {
     }
 
     /**
-     * - Returns the access control entries (ACEs) configured on the entry, both explicitly-set and inherited (inherited ACEs carry isInherited = true), plus whether the entry inherits rights from its parent(s).
+     * - Returns the access control entries (ACEs) configured on the entry — by default both explicitly-set and inherited (inherited ACEs carry isInherited = true), or only the explicit ones when includeInherited=false — plus whether the entry inherits rights from its parent(s).
     - Each ACE names a trustee, whether its rights are allowed or denied, the rights themselves, and the propagation scope.
     - The repository session enforces the underlying permission: reading an ACL requires the ReadPermissions right on the entry, and a 403 is returned when it is lacking. The repository.Read OAuth scope is necessary but not sufficient.
     - Required OAuth scope: repository.Read
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry whose access control list is returned.
+     * @param args.includeInherited (optional) Optional. When true (the default), the response includes both the entry's explicit access control entries and the inherited ones (inherited ACEs carry isInherited = true). When false, only the explicit ACEs are returned — the exact set that the access-control PUT accepts — making it convenient to read, edit, and write back the ACL without filtering inherited entries client-side. The inheritParents flag is unaffected by this option.
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the entry's access control list.
      */
-    getEntryAccessControl(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AccessControlList> {
-        let { repositoryId, entryId, select } = args;
+    getEntryAccessControl(args: { repositoryId: string, entryId: number, includeInherited?: boolean | undefined, select?: string | null | undefined }): Promise<AccessControlList> {
+        let { repositoryId, entryId, includeInherited, select } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/AccessControl?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -8027,6 +8016,10 @@ export class EntriesClient implements IEntriesClient {
         if (entryId === undefined || entryId === null)
             throw new Error("The parameter 'entryId' must be defined.");
         url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (includeInherited === null)
+            throw new Error("The parameter 'includeInherited' cannot be null.");
+        else if (includeInherited !== undefined)
+            url_ += "includeInherited=" + encodeURIComponent("" + includeInherited) + "&";
         if (select !== undefined && select !== null)
             url_ += "$select=" + encodeURIComponent("" + select) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -8203,20 +8196,21 @@ export class EntriesClient implements IEntriesClient {
     }
 
     /**
-     * - Returns the net rights a trustee effectively has on the entry after inheritance, group membership, and allow/deny resolution are applied by the repository server. This is the same effective-rights calculation the Laserfiche applications use.
+     * - Returns the rights a trustee has on the entry. By default these are the effective rights — the same calculation the Laserfiche applications use, after allow/deny resolution, group membership, and the repository's privilege and records-management overlays. Set aclOnly=true to return only the rights granted by the entry's access control list (including its stored inherited ACEs) without the privilege/records-management overlays.
     - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
     - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
     - Required OAuth scope: repository.Read
      * @param args.repositoryId The requested repository ID.
-     * @param args.entryId The entry whose effective rights are computed.
-     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute effective rights for. When omitted (along with trusteeName), the effective rights of the current session are returned.
-     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute effective rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
+     * @param args.entryId The entry whose rights are computed.
+     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute rights for. When omitted (along with trusteeName), the rights of the current session are returned.
+     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
+     * @param args.aclOnly (optional) Optional. Selects which rights are returned. Default (false): the trustee's effective rights — the net result after allow/deny resolution, group membership, and the repository's privilege and records-management overlays. When true: only the rights granted by this item's access control list — including inherited access control entries, which are stored on the item itself — without the privilege and records-management overlays (for example, a privilege that grants full control regardless of the ACL is reflected only when aclOnly=false). Group membership is always resolved. The aclOnly=true value is what the ACL editor displays as the net effect of the list.
      * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the effective rights for the entry.
+     * @returns Successfully returned the rights for the entry.
      */
-    getEntryEffectiveRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights> {
-        let { repositoryId, entryId, trusteeId, trusteeName, select } = args;
-        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/EffectiveRights?";
+    getEntryRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, aclOnly?: boolean | undefined, select?: string | null | undefined }): Promise<EntryRights> {
+        let { repositoryId, entryId, trusteeId, trusteeName, aclOnly, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Rights?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
         url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
@@ -8227,6 +8221,10 @@ export class EntriesClient implements IEntriesClient {
             url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
         if (trusteeName !== undefined && trusteeName !== null)
             url_ += "trusteeName=" + encodeURIComponent("" + trusteeName) + "&";
+        if (aclOnly === null)
+            throw new Error("The parameter 'aclOnly' cannot be null.");
+        else if (aclOnly !== undefined)
+            url_ += "aclOnly=" + encodeURIComponent("" + aclOnly) + "&";
         if (select !== undefined && select !== null)
             url_ += "$select=" + encodeURIComponent("" + select) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -8239,18 +8237,18 @@ export class EntriesClient implements IEntriesClient {
         };
 
         return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processGetEntryEffectiveRights(_response);
+            return this.processGetEntryRights(_response);
         });
     }
 
-    protected processGetEntryEffectiveRights(response: Response): Promise<EffectiveRights> {
+    protected processGetEntryRights(response: Response): Promise<EntryRights> {
         const status = response.status;
         let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
         if (status === 200) {
             return response.text().then((_responseText) => {
             let result200: any = null;
             let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = EffectiveRights.fromJS(resultData200);
+            result200 = EntryRights.fromJS(resultData200);
             return result200;
             });
         } else if (status === 400) {
@@ -8300,108 +8298,7 @@ export class EntriesClient implements IEntriesClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
             });
         }
-        return Promise.resolve<EffectiveRights>(null as any);
-    }
-
-    /**
-     * - Returns the rights granted by this entry's own ACL, excluding inheritance from parent folders and privilege/records-management overlays; group membership is still resolved. Contrast with EffectiveRights, which returns the net rights after inheritance and overlays are applied.
-    - Identify the trustee by trusteeId (a SID) or trusteeName (an account name); omit both for the calling session.
-    - isReadOnly reports whether the session is read-only, in which case no write operations are possible regardless of the granted rights.
-    - Required OAuth scope: repository.Read
-     * @param args.repositoryId The requested repository ID.
-     * @param args.entryId The entry whose direct rights are computed.
-     * @param args.trusteeId (optional) Optional. The SID of the trustee to compute direct rights for. When omitted (along with trusteeName), the direct rights of the current session are returned.
-     * @param args.trusteeName (optional) Optional. The account name of the trustee to compute direct rights for, as an alternative to trusteeId. When both are supplied, trusteeId takes precedence.
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the direct (ACL) rights for the entry.
-     */
-    getEntryDirectRights(args: { repositoryId: string, entryId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, select?: string | null | undefined }): Promise<EffectiveRights> {
-        let { repositoryId, entryId, trusteeId, trusteeName, select } = args;
-        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/DirectRights?";
-        if (repositoryId === undefined || repositoryId === null)
-            throw new Error("The parameter 'repositoryId' must be defined.");
-        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
-        if (entryId === undefined || entryId === null)
-            throw new Error("The parameter 'entryId' must be defined.");
-        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
-        if (trusteeId !== undefined && trusteeId !== null)
-            url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
-        if (trusteeName !== undefined && trusteeName !== null)
-            url_ += "trusteeName=" + encodeURIComponent("" + trusteeName) + "&";
-        if (select !== undefined && select !== null)
-            url_ += "$select=" + encodeURIComponent("" + select) + "&";
-        url_ = url_.replace(/[?&]$/, "");
-
-        let options_: RequestInit = {
-            method: "GET",
-            headers: {
-                "Accept": "application/json"
-            }
-        };
-
-        return this.http.fetch(url_, options_).then((_response: Response) => {
-            return this.processGetEntryDirectRights(_response);
-        });
-    }
-
-    protected processGetEntryDirectRights(response: Response): Promise<EffectiveRights> {
-        const status = response.status;
-        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
-        if (status === 200) {
-            return response.text().then((_responseText) => {
-            let result200: any = null;
-            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result200 = EffectiveRights.fromJS(resultData200);
-            return result200;
-            });
-        } else if (status === 400) {
-            return response.text().then((_responseText) => {
-            let result400: any = null;
-            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result400 = ProblemDetails.fromJS(resultData400);
-            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
-            });
-        } else if (status === 401) {
-            return response.text().then((_responseText) => {
-            let result401: any = null;
-            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result401 = ProblemDetails.fromJS(resultData401);
-            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
-            });
-        } else if (status === 403) {
-            return response.text().then((_responseText) => {
-            let result403: any = null;
-            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result403 = ProblemDetails.fromJS(resultData403);
-            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
-            });
-        } else if (status === 404) {
-            return response.text().then((_responseText) => {
-            let result404: any = null;
-            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result404 = ProblemDetails.fromJS(resultData404);
-            return throwException("Entry with requested ID was not found.", status, _responseText, _headers, result404);
-            });
-        } else if (status === 429) {
-            return response.text().then((_responseText) => {
-            let result429: any = null;
-            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result429 = ProblemDetails.fromJS(resultData429);
-            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
-            });
-        } else if (status === 500) {
-            return response.text().then((_responseText) => {
-            let result500: any = null;
-            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
-            result500 = ProblemDetails.fromJS(resultData500);
-            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
-            });
-        } else if (status !== 200 && status !== 204) {
-            return response.text().then((_responseText) => {
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-            });
-        }
-        return Promise.resolve<EffectiveRights>(null as any);
+        return Promise.resolve<EntryRights>(null as any);
     }
 }
 
@@ -17559,9 +17456,9 @@ from parent inheritance; when true, parent rights are inherited. */
     inheritParents?: boolean | undefined;
 }
 
-/** A trustee's effective rights to an entry — the net rights after inheritance, group membership, and allow/deny resolution are applied by the repository server. */
-export class EffectiveRights implements IEffectiveRights {
-    /** The rights effectively granted to the trustee on the entry. */
+/** A trustee's rights to an entry. Depending on the aclOnly option on the request, these are either the effective rights (the net result after allow/deny resolution, group membership, and the repository's privilege and records-management overlays) or the rights granted by the entry's access control list alone. */
+export class EntryRights implements IEntryRights {
+    /** The rights granted to the trustee on the entry. */
     rights?: EntryRight[] | undefined;
     /** True when the session is read-only, so no write operations are possible regardless of
 the granted rights. */
@@ -17569,7 +17466,7 @@ the granted rights. */
 
     
     
-    constructor(data?: IEffectiveRights) {
+    constructor(data?: IEntryRights) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -17589,9 +17486,9 @@ the granted rights. */
         }
     }
 
-    static fromJS(data: any): EffectiveRights {
+    static fromJS(data: any): EntryRights {
         data = typeof data === 'object' ? data : {};
-        let result = new EffectiveRights();
+        let result = new EntryRights();
         result.init(data);
         return result;
     }
@@ -17608,9 +17505,9 @@ the granted rights. */
     }
 }
 
-/** A trustee's effective rights to an entry — the net rights after inheritance, group membership, and allow/deny resolution are applied by the repository server. */
-export interface IEffectiveRights {
-    /** The rights effectively granted to the trustee on the entry. */
+/** A trustee's rights to an entry. Depending on the aclOnly option on the request, these are either the effective rights (the net result after allow/deny resolution, group membership, and the repository's privilege and records-management overlays) or the rights granted by the entry's access control list alone. */
+export interface IEntryRights {
+    /** The rights granted to the trustee on the entry. */
     rights?: EntryRight[] | undefined;
     /** True when the session is read-only, so no write operations are possible regardless of
 the granted rights. */

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -645,6 +645,56 @@ export interface IFieldDefinitionsClient {
      * @returns Successfully changed the field definition's type.
      */
     changeFieldType(args: { repositoryId: string, fieldId: number, request: ChangeFieldTypeRequest }): Promise<FieldDefinition>;
+
+    /**
+     * - Returns the field's access control entries (ACEs): the trustee, whether rights are allowed or denied, and the rights themselves. Field ACEs have no scope and are never inherited.
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the field's ReadPermissions right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The requested field definition ID.
+     * @returns Successfully returned the field definition's access control list.
+     */
+    getFieldAccessControl(args: { repositoryId: string, fieldId: number }): Promise<FieldAccessControlList>;
+
+    /**
+     * - Full replace: the supplied entries replace the field's entire explicit ACL. Inherited entries are not accepted (field ACEs are never inherited). Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given; an account name is resolved to a SID server-side).
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the field's ChangePermissions right.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The field definition ID whose ACL to replace.
+     * @param args.request The access control entries to set.
+     * @returns Successfully replaced the field definition's access control list. Returned the updated access control list.
+     */
+    setFieldAccessControl(args: { repositoryId: string, fieldId: number, request: SetFieldAccessControlRequest }): Promise<FieldAccessControlList>;
+
+    /**
+     * - Returns the rights a trustee has on the field definition, plus whether the session is read-only. By default these are the effective rights (after group membership, allow/deny resolution, and the privilege overlay); set aclOnly=true for the rights granted by the field's own ACL without that overlay. Omit both trusteeId and trusteeName for the current session.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The requested field definition ID.
+     * @param args.trusteeId (optional) An optional trustee SID. When supplied, returns that trustee's rights; otherwise the current session's.
+     * @param args.trusteeName (optional) An optional trustee account name, as an alternative to trusteeId. The SID wins when both are supplied.
+     * @param args.aclOnly (optional) Optional. Selects which rights are returned. Default (false): the trustee's effective rights — the net result after allow/deny resolution, group membership, and the repository's privilege overlay (for example, the metadata-management privilege that grants full control over every field regardless of its ACL). When true: only the rights granted by this field definition's own access control list, without that privilege overlay. Group membership is always resolved. Field definitions are not hierarchical, so there is no parent inheritance involved either way.
+     * @returns Successfully returned the rights for the field definition.
+     */
+    getFieldRights(args: { repositoryId: string, fieldId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, aclOnly?: boolean | undefined }): Promise<FieldRights>;
+
+    /**
+     * - Returns the repository's default field ACL — the access control entries a new field definition inherits at creation time.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @returns Successfully returned the default field access control list.
+     */
+    getDefaultFieldAccessControl(args: { repositoryId: string }): Promise<FieldAccessControlList>;
+
+    /**
+     * - Full replace: the supplied entries replace the entire default field ACL. Inherited entries are not accepted. Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.request The access control entries to set as the default field ACL.
+     * @returns Successfully replaced the default field access control list. Returned the updated default access control list.
+     */
+    setDefaultFieldAccessControl(args: { repositoryId: string, request: SetFieldAccessControlRequest }): Promise<FieldAccessControlList>;
 }
 
 export class FieldDefinitionsClient implements IFieldDefinitionsClient {
@@ -1985,6 +2035,457 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
             });
         }
         return Promise.resolve<FieldDefinition>(null as any);
+    }
+
+    /**
+     * - Returns the field's access control entries (ACEs): the trustee, whether rights are allowed or denied, and the rights themselves. Field ACEs have no scope and are never inherited.
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the field's ReadPermissions right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The requested field definition ID.
+     * @returns Successfully returned the field definition's access control list.
+     */
+    getFieldAccessControl(args: { repositoryId: string, fieldId: number }): Promise<FieldAccessControlList> {
+        let { repositoryId, fieldId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetFieldAccessControl(_response);
+        });
+    }
+
+    protected processGetFieldAccessControl(response: Response): Promise<FieldAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldAccessControlList>(null as any);
+    }
+
+    /**
+     * - Full replace: the supplied entries replace the field's entire explicit ACL. Inherited entries are not accepted (field ACEs are never inherited). Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given; an account name is resolved to a SID server-side).
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the field's ChangePermissions right.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The field definition ID whose ACL to replace.
+     * @param args.request The access control entries to set.
+     * @returns Successfully replaced the field definition's access control list. Returned the updated access control list.
+     */
+    setFieldAccessControl(args: { repositoryId: string, fieldId: number, request: SetFieldAccessControlRequest }): Promise<FieldAccessControlList> {
+        let { repositoryId, fieldId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetFieldAccessControl(_response);
+        });
+    }
+
+    protected processSetFieldAccessControl(response: Response): Promise<FieldAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldAccessControlList>(null as any);
+    }
+
+    /**
+     * - Returns the rights a trustee has on the field definition, plus whether the session is read-only. By default these are the effective rights (after group membership, allow/deny resolution, and the privilege overlay); set aclOnly=true for the rights granted by the field's own ACL without that overlay. Omit both trusteeId and trusteeName for the current session.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.fieldId The requested field definition ID.
+     * @param args.trusteeId (optional) An optional trustee SID. When supplied, returns that trustee's rights; otherwise the current session's.
+     * @param args.trusteeName (optional) An optional trustee account name, as an alternative to trusteeId. The SID wins when both are supplied.
+     * @param args.aclOnly (optional) Optional. Selects which rights are returned. Default (false): the trustee's effective rights — the net result after allow/deny resolution, group membership, and the repository's privilege overlay (for example, the metadata-management privilege that grants full control over every field regardless of its ACL). When true: only the rights granted by this field definition's own access control list, without that privilege overlay. Group membership is always resolved. Field definitions are not hierarchical, so there is no parent inheritance involved either way.
+     * @returns Successfully returned the rights for the field definition.
+     */
+    getFieldRights(args: { repositoryId: string, fieldId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, aclOnly?: boolean | undefined }): Promise<FieldRights> {
+        let { repositoryId, fieldId, trusteeId, trusteeName, aclOnly } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Rights?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (fieldId === undefined || fieldId === null)
+            throw new Error("The parameter 'fieldId' must be defined.");
+        url_ = url_.replace("{fieldId}", encodeURIComponent("" + fieldId));
+        if (trusteeId !== undefined && trusteeId !== null)
+            url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
+        if (trusteeName !== undefined && trusteeName !== null)
+            url_ += "trusteeName=" + encodeURIComponent("" + trusteeName) + "&";
+        if (aclOnly === null)
+            throw new Error("The parameter 'aclOnly' cannot be null.");
+        else if (aclOnly !== undefined)
+            url_ += "aclOnly=" + encodeURIComponent("" + aclOnly) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetFieldRights(_response);
+        });
+    }
+
+    protected processGetFieldRights(response: Response): Promise<FieldRights> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldRights.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Field definition with specified id was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldRights>(null as any);
+    }
+
+    /**
+     * - Returns the repository's default field ACL — the access control entries a new field definition inherits at creation time.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @returns Successfully returned the default field access control list.
+     */
+    getDefaultFieldAccessControl(args: { repositoryId: string }): Promise<FieldAccessControlList> {
+        let { repositoryId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/DefaultAccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetDefaultFieldAccessControl(_response);
+        });
+    }
+
+    protected processGetDefaultFieldAccessControl(response: Response): Promise<FieldAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldAccessControlList>(null as any);
+    }
+
+    /**
+     * - Full replace: the supplied entries replace the entire default field ACL. Inherited entries are not accepted. Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.request The access control entries to set as the default field ACL.
+     * @returns Successfully replaced the default field access control list. Returned the updated default access control list.
+     */
+    setDefaultFieldAccessControl(args: { repositoryId: string, request: SetFieldAccessControlRequest }): Promise<FieldAccessControlList> {
+        let { repositoryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/FieldDefinitions/DefaultAccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetDefaultFieldAccessControl(_response);
+        });
+    }
+
+    protected processSetDefaultFieldAccessControl(response: Response): Promise<FieldAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = FieldAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FieldAccessControlList>(null as any);
     }
 }
 
@@ -8310,6 +8811,15 @@ export interface IRepositoriesClient {
      * @returns Successfully returned list of available repositories.
      */
     listRepositories(args: {  }): Promise<RepositoryCollectionResponse>;
+
+    /**
+     * - Returns the privileges and feature rights held by the current session, plus whether the session is read-only. Each is reported as named booleans (a map of right name to whether it is granted), for UI enablement and pre-flight checks.
+    - Reflects the current session only. Per-trustee privilege administration is not part of this surface.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @returns Successfully returned the current session's rights.
+     */
+    getSessionRights(args: { repositoryId: string }): Promise<SessionRights>;
 }
 
 export class RepositoriesClient implements IRepositoriesClient {
@@ -8411,6 +8921,86 @@ export class RepositoriesClient implements IRepositoriesClient {
             });
         }
         return Promise.resolve<RepositoryCollectionResponse>(null as any);
+    }
+
+    /**
+     * - Returns the privileges and feature rights held by the current session, plus whether the session is read-only. Each is reported as named booleans (a map of right name to whether it is granted), for UI enablement and pre-flight checks.
+    - Reflects the current session only. Per-trustee privilege administration is not part of this surface.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @returns Successfully returned the current session's rights.
+     */
+    getSessionRights(args: { repositoryId: string }): Promise<SessionRights> {
+        let { repositoryId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/SessionRights";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetSessionRights(_response);
+        });
+    }
+
+    protected processGetSessionRights(response: Response): Promise<SessionRights> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = SessionRights.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<SessionRights>(null as any);
     }
 }
 
@@ -10043,6 +10633,56 @@ export interface ITemplateDefinitionsClient {
      * @returns Successfully moved the field to the new position in the template.
      */
     moveTemplateField(args: { repositoryId: string, templateId: number, request: MoveTemplateFieldRequest }): Promise<void>;
+
+    /**
+     * - Returns the template's access control entries (ACEs): the trustee, whether rights are allowed or denied, and the rights themselves. Template ACEs have no scope and are never inherited.
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the template's ReadPermissions right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.templateId The requested template definition ID.
+     * @returns Successfully returned the template definition's access control list.
+     */
+    getTemplateAccessControl(args: { repositoryId: string, templateId: number }): Promise<TemplateAccessControlList>;
+
+    /**
+     * - Full replace: the supplied entries replace the template's entire explicit ACL. Inherited entries are not accepted (template ACEs are never inherited). Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given; an account name is resolved to a SID server-side).
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the template's ChangePermissions right.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.templateId The template definition ID whose ACL to replace.
+     * @param args.request The access control entries to set.
+     * @returns Successfully replaced the template definition's access control list. Returned the updated access control list.
+     */
+    setTemplateAccessControl(args: { repositoryId: string, templateId: number, request: SetTemplateAccessControlRequest }): Promise<TemplateAccessControlList>;
+
+    /**
+     * - Returns the rights a trustee has on the template definition, plus whether the session is read-only. By default these are the effective rights (after group membership, allow/deny resolution, and the privilege overlay); set aclOnly=true for the rights granted by the template's own ACL without that overlay. Omit both trusteeId and trusteeName for the current session.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.templateId The requested template definition ID.
+     * @param args.trusteeId (optional) An optional trustee SID. When supplied, returns that trustee's rights; otherwise the current session's.
+     * @param args.trusteeName (optional) An optional trustee account name, as an alternative to trusteeId. The SID wins when both are supplied.
+     * @param args.aclOnly (optional) Optional. Selects which rights are returned. Default (false): the trustee's effective rights — the net result after allow/deny resolution, group membership, and the repository's privilege overlay (for example, the metadata-management privilege that grants full control over every template regardless of its ACL). When true: only the rights granted by this template definition's own access control list, without that privilege overlay. Group membership is always resolved. Template definitions are not hierarchical, so there is no parent inheritance involved either way.
+     * @returns Successfully returned the rights for the template definition.
+     */
+    getTemplateRights(args: { repositoryId: string, templateId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, aclOnly?: boolean | undefined }): Promise<TemplateRights>;
+
+    /**
+     * - Returns the repository's default template ACL — the access control entries a new template definition inherits at creation time.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @returns Successfully returned the default template access control list.
+     */
+    getDefaultTemplateAccessControl(args: { repositoryId: string }): Promise<TemplateAccessControlList>;
+
+    /**
+     * - Full replace: the supplied entries replace the entire default template ACL. Inherited entries are not accepted. Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.request The access control entries to set as the default template ACL.
+     * @returns Successfully replaced the default template access control list. Returned the updated default access control list.
+     */
+    setDefaultTemplateAccessControl(args: { repositoryId: string, request: SetTemplateAccessControlRequest }): Promise<TemplateAccessControlList>;
 }
 
 export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
@@ -11685,6 +12325,457 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
         }
         return Promise.resolve<void>(null as any);
     }
+
+    /**
+     * - Returns the template's access control entries (ACEs): the trustee, whether rights are allowed or denied, and the rights themselves. Template ACEs have no scope and are never inherited.
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the template's ReadPermissions right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.templateId The requested template definition ID.
+     * @returns Successfully returned the template definition's access control list.
+     */
+    getTemplateAccessControl(args: { repositoryId: string, templateId: number }): Promise<TemplateAccessControlList> {
+        let { repositoryId, templateId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (templateId === undefined || templateId === null)
+            throw new Error("The parameter 'templateId' must be defined.");
+        url_ = url_.replace("{templateId}", encodeURIComponent("" + templateId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetTemplateAccessControl(_response);
+        });
+    }
+
+    protected processGetTemplateAccessControl(response: Response): Promise<TemplateAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = TemplateAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Template with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TemplateAccessControlList>(null as any);
+    }
+
+    /**
+     * - Full replace: the supplied entries replace the template's entire explicit ACL. Inherited entries are not accepted (template ACEs are never inherited). Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given; an account name is resolved to a SID server-side).
+    - The OAuth scope is coarse; the repository session enforces the real permission and returns 403 when the caller lacks the template's ChangePermissions right.
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.templateId The template definition ID whose ACL to replace.
+     * @param args.request The access control entries to set.
+     * @returns Successfully replaced the template definition's access control list. Returned the updated access control list.
+     */
+    setTemplateAccessControl(args: { repositoryId: string, templateId: number, request: SetTemplateAccessControlRequest }): Promise<TemplateAccessControlList> {
+        let { repositoryId, templateId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (templateId === undefined || templateId === null)
+            throw new Error("The parameter 'templateId' must be defined.");
+        url_ = url_.replace("{templateId}", encodeURIComponent("" + templateId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetTemplateAccessControl(_response);
+        });
+    }
+
+    protected processSetTemplateAccessControl(response: Response): Promise<TemplateAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = TemplateAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Template with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TemplateAccessControlList>(null as any);
+    }
+
+    /**
+     * - Returns the rights a trustee has on the template definition, plus whether the session is read-only. By default these are the effective rights (after group membership, allow/deny resolution, and the privilege overlay); set aclOnly=true for the rights granted by the template's own ACL without that overlay. Omit both trusteeId and trusteeName for the current session.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.templateId The requested template definition ID.
+     * @param args.trusteeId (optional) An optional trustee SID. When supplied, returns that trustee's rights; otherwise the current session's.
+     * @param args.trusteeName (optional) An optional trustee account name, as an alternative to trusteeId. The SID wins when both are supplied.
+     * @param args.aclOnly (optional) Optional. Selects which rights are returned. Default (false): the trustee's effective rights — the net result after allow/deny resolution, group membership, and the repository's privilege overlay (for example, the metadata-management privilege that grants full control over every template regardless of its ACL). When true: only the rights granted by this template definition's own access control list, without that privilege overlay. Group membership is always resolved. Template definitions are not hierarchical, so there is no parent inheritance involved either way.
+     * @returns Successfully returned the rights for the template definition.
+     */
+    getTemplateRights(args: { repositoryId: string, templateId: number, trusteeId?: string | null | undefined, trusteeName?: string | null | undefined, aclOnly?: boolean | undefined }): Promise<TemplateRights> {
+        let { repositoryId, templateId, trusteeId, trusteeName, aclOnly } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Rights?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (templateId === undefined || templateId === null)
+            throw new Error("The parameter 'templateId' must be defined.");
+        url_ = url_.replace("{templateId}", encodeURIComponent("" + templateId));
+        if (trusteeId !== undefined && trusteeId !== null)
+            url_ += "trusteeId=" + encodeURIComponent("" + trusteeId) + "&";
+        if (trusteeName !== undefined && trusteeName !== null)
+            url_ += "trusteeName=" + encodeURIComponent("" + trusteeName) + "&";
+        if (aclOnly === null)
+            throw new Error("The parameter 'aclOnly' cannot be null.");
+        else if (aclOnly !== undefined)
+            url_ += "aclOnly=" + encodeURIComponent("" + aclOnly) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetTemplateRights(_response);
+        });
+    }
+
+    protected processGetTemplateRights(response: Response): Promise<TemplateRights> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = TemplateRights.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Template with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TemplateRights>(null as any);
+    }
+
+    /**
+     * - Returns the repository's default template ACL — the access control entries a new template definition inherits at creation time.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @returns Successfully returned the default template access control list.
+     */
+    getDefaultTemplateAccessControl(args: { repositoryId: string }): Promise<TemplateAccessControlList> {
+        let { repositoryId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/TemplateDefinitions/DefaultAccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetDefaultTemplateAccessControl(_response);
+        });
+    }
+
+    protected processGetDefaultTemplateAccessControl(response: Response): Promise<TemplateAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = TemplateAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TemplateAccessControlList>(null as any);
+    }
+
+    /**
+     * - Full replace: the supplied entries replace the entire default template ACL. Inherited entries are not accepted. Address a trustee by trustee.sid or trustee.accountName (the SID wins when both are given).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.request The access control entries to set as the default template ACL.
+     * @returns Successfully replaced the default template access control list. Returned the updated default access control list.
+     */
+    setDefaultTemplateAccessControl(args: { repositoryId: string, request: SetTemplateAccessControlRequest }): Promise<TemplateAccessControlList> {
+        let { repositoryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/TemplateDefinitions/DefaultAccessControl";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetDefaultTemplateAccessControl(_response);
+        });
+    }
+
+    protected processSetDefaultTemplateAccessControl(response: Response): Promise<TemplateAccessControlList> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = TemplateAccessControlList.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TemplateAccessControlList>(null as any);
+    }
 }
 
 export interface ITrusteesClient {
@@ -11700,6 +12791,16 @@ export interface ITrusteesClient {
      * @returns Successfully returned the matching trustees.
      */
     lookupTrustees(args: { repositoryId: string, search?: string | null | undefined, type?: string | null | undefined, count?: number | undefined }): Promise<TrusteeIdentity[]>;
+
+    /**
+     * - Returns the trustee's effective privileges and feature rights (as named booleans), the security tags assigned to it, the audit classes configured for it (split into success and failure masks), and whether the trustee is read-only.
+    - This is a best-effort computation that can, in rare cases, differ from the trustee's real rights. The authoritative way to determine a trustee's security is to sign in as that trustee and read the resulting session's rights.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.trusteeId The SID of the trustee whose effective security is computed. Use the trustee lookup to resolve a name to a SID.
+     * @returns Successfully returned the trustee's effective account security.
+     */
+    getTrusteeEffectiveSecurity(args: { repositoryId: string, trusteeId: string }): Promise<TrusteeEffectiveSecurity>;
 }
 
 export class TrusteesClient implements ITrusteesClient {
@@ -11808,6 +12909,97 @@ export class TrusteesClient implements ITrusteesClient {
             });
         }
         return Promise.resolve<TrusteeIdentity[]>(null as any);
+    }
+
+    /**
+     * - Returns the trustee's effective privileges and feature rights (as named booleans), the security tags assigned to it, the audit classes configured for it (split into success and failure masks), and whether the trustee is read-only.
+    - This is a best-effort computation that can, in rare cases, differ from the trustee's real rights. The authoritative way to determine a trustee's security is to sign in as that trustee and read the resulting session's rights.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.trusteeId The SID of the trustee whose effective security is computed. Use the trustee lookup to resolve a name to a SID.
+     * @returns Successfully returned the trustee's effective account security.
+     */
+    getTrusteeEffectiveSecurity(args: { repositoryId: string, trusteeId: string }): Promise<TrusteeEffectiveSecurity> {
+        let { repositoryId, trusteeId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Trustees/{trusteeId}/EffectiveSecurity";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (trusteeId === undefined || trusteeId === null)
+            throw new Error("The parameter 'trusteeId' must be defined.");
+        url_ = url_.replace("{trusteeId}", encodeURIComponent("" + trusteeId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetTrusteeEffectiveSecurity(_response);
+        });
+    }
+
+    protected processGetTrusteeEffectiveSecurity(response: Response): Promise<TrusteeEffectiveSecurity> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = TrusteeEffectiveSecurity.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<TrusteeEffectiveSecurity>(null as any);
     }
 }
 
@@ -13321,6 +14513,348 @@ or any assigned entries, AND the conversion is not one of the explicit safe wide
 LongInteger → Number). A lossy conversion without this flag returns 400
 (data_loss_expected). Lossless conversions ignore this flag. */
     allowDataLoss?: boolean;
+}
+
+/** The access control list (ACL) of a template field definition: its access control entries. Field ACLs have no parent inheritance, so there is no inherit-parents flag. */
+export class FieldAccessControlList implements IFieldAccessControlList {
+    /** The access control entries that make up the ACL. */
+    entries?: FieldAccessControlEntry[] | undefined;
+
+    
+    
+    constructor(data?: IFieldAccessControlList) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entries"])) {
+                this.entries = [] as any;
+                for (let item of _data["entries"])
+                    this.entries!.push(FieldAccessControlEntry.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): FieldAccessControlList {
+        data = typeof data === 'object' ? data : {};
+        let result = new FieldAccessControlList();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entries)) {
+            data["entries"] = [];
+            for (let item of this.entries)
+                data["entries"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+/** The access control list (ACL) of a template field definition: its access control entries. Field ACLs have no parent inheritance, so there is no inherit-parents flag. */
+export interface IFieldAccessControlList {
+    /** The access control entries that make up the ACL. */
+    entries?: FieldAccessControlEntry[] | undefined;
+}
+
+/** A single access control entry (ACE) on a template field definition: one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. Unlike entry ACEs, field ACEs have no scope and are never inherited. */
+export class FieldAccessControlEntry implements IFieldAccessControlEntry {
+    /** The trustee this ACE applies to. On input, identify the trustee by either
+trustee.sid or trustee.accountName (the SID takes precedence when both are given). */
+    trustee?: TrusteeIdentity | undefined;
+    /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. Required on
+input — a missing value is rejected (it must not silently default to Allow). */
+    accessControlType?: AccessControlType | undefined;
+    /** The rights granted or denied by this ACE. */
+    rights?: FieldRight[] | undefined;
+    /** True when this ACE is inherited. Always false for field ACEs (field definitions have no
+ACL inheritance); returned for contract symmetry and ignored on input. */
+    isInherited?: boolean;
+    /** When inherited, a description of where the ACE was inherited from. Output only; null for
+field ACEs. */
+    inheritedFrom?: string | undefined;
+
+    
+    
+    constructor(data?: IFieldAccessControlEntry) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.trustee = _data["trustee"] ? TrusteeIdentity.fromJS(_data["trustee"]) : <any>undefined;
+            this.accessControlType = _data["accessControlType"];
+            if (Array.isArray(_data["rights"])) {
+                this.rights = [] as any;
+                for (let item of _data["rights"])
+                    this.rights!.push(item);
+            }
+            this.isInherited = _data["isInherited"];
+            this.inheritedFrom = _data["inheritedFrom"];
+        }
+    }
+
+    static fromJS(data: any): FieldAccessControlEntry {
+        data = typeof data === 'object' ? data : {};
+        let result = new FieldAccessControlEntry();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["trustee"] = this.trustee ? this.trustee.toJSON() : <any>undefined;
+        data["accessControlType"] = this.accessControlType;
+        if (Array.isArray(this.rights)) {
+            data["rights"] = [];
+            for (let item of this.rights)
+                data["rights"].push(item);
+        }
+        data["isInherited"] = this.isInherited;
+        data["inheritedFrom"] = this.inheritedFrom;
+        return data;
+    }
+}
+
+/** A single access control entry (ACE) on a template field definition: one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. Unlike entry ACEs, field ACEs have no scope and are never inherited. */
+export interface IFieldAccessControlEntry {
+    /** The trustee this ACE applies to. On input, identify the trustee by either
+trustee.sid or trustee.accountName (the SID takes precedence when both are given). */
+    trustee?: TrusteeIdentity | undefined;
+    /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. Required on
+input — a missing value is rejected (it must not silently default to Allow). */
+    accessControlType?: AccessControlType | undefined;
+    /** The rights granted or denied by this ACE. */
+    rights?: FieldRight[] | undefined;
+    /** True when this ACE is inherited. Always false for field ACEs (field definitions have no
+ACL inheritance); returned for contract symmetry and ignored on input. */
+    isInherited?: boolean;
+    /** When inherited, a description of where the ACE was inherited from. Output only; null for
+field ACEs. */
+    inheritedFrom?: string | undefined;
+}
+
+/** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
+export class TrusteeIdentity implements ITrusteeIdentity {
+    /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
+the canonical, stable id for a trustee. On input it is preferred and takes precedence over
+AccountName; always populated on output. */
+    sid?: string | undefined;
+    /** The trustee's account name. On input it may be supplied instead of Sid to
+address the trustee by name (resolved to a SID server-side); the SID wins when both are
+given. Always populated on output. */
+    accountName?: string | undefined;
+    /** The trustee type: one of LaserficheUser, LaserficheGroup,
+WindowsAccount, LdapAccount, LfdsAccount. */
+    trusteeType?: string | undefined;
+    /** True when the trustee is an individual user; false when it is a group. */
+    isUser?: boolean;
+    /** A human-readable display name. Populated by trustee-lookup results; omitted in
+access-control-entry contexts. */
+    displayName?: string | undefined;
+    /** True when the trustee account is disabled. Populated by trustee-lookup results. */
+    isDisabled?: boolean;
+
+    
+    
+    constructor(data?: ITrusteeIdentity) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.sid = _data["sid"];
+            this.accountName = _data["accountName"];
+            this.trusteeType = _data["trusteeType"];
+            this.isUser = _data["isUser"];
+            this.displayName = _data["displayName"];
+            this.isDisabled = _data["isDisabled"];
+        }
+    }
+
+    static fromJS(data: any): TrusteeIdentity {
+        data = typeof data === 'object' ? data : {};
+        let result = new TrusteeIdentity();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["sid"] = this.sid;
+        data["accountName"] = this.accountName;
+        data["trusteeType"] = this.trusteeType;
+        data["isUser"] = this.isUser;
+        data["displayName"] = this.displayName;
+        data["isDisabled"] = this.isDisabled;
+        return data;
+    }
+}
+
+/** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
+export interface ITrusteeIdentity {
+    /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
+the canonical, stable id for a trustee. On input it is preferred and takes precedence over
+AccountName; always populated on output. */
+    sid?: string | undefined;
+    /** The trustee's account name. On input it may be supplied instead of Sid to
+address the trustee by name (resolved to a SID server-side); the SID wins when both are
+given. Always populated on output. */
+    accountName?: string | undefined;
+    /** The trustee type: one of LaserficheUser, LaserficheGroup,
+WindowsAccount, LdapAccount, LfdsAccount. */
+    trusteeType?: string | undefined;
+    /** True when the trustee is an individual user; false when it is a group. */
+    isUser?: boolean;
+    /** A human-readable display name. Populated by trustee-lookup results; omitted in
+access-control-entry contexts. */
+    displayName?: string | undefined;
+    /** True when the trustee account is disabled. Populated by trustee-lookup results. */
+    isDisabled?: boolean;
+}
+
+/** Whether an access control entry (ACE) grants or denies its rights. Serialized by name. */
+export enum AccessControlType {
+    Allow = "Allow",
+    Deny = "Deny",
+}
+
+/** An individual access right that can be granted to or denied a trustee on a template field definition. Serialized by name; emitted as a string enum in the OpenAPI schema so clients can reference it directly. */
+export enum FieldRight {
+    ReadValue = "ReadValue",
+    SetValue = "SetValue",
+    SetValueOnce = "SetValueOnce",
+    ModifyDefinition = "ModifyDefinition",
+    Delete = "Delete",
+    ReadPermissions = "ReadPermissions",
+    ChangePermissions = "ChangePermissions",
+    TakeOwnership = "TakeOwnership",
+}
+
+/** Request body for replacing a template field definition's access control list. The supplied entries fully replace the field's existing explicit ACL. Inherited entries are not accepted. */
+export class SetFieldAccessControlRequest implements ISetFieldAccessControlRequest {
+    /** The access control entries to set. Replaces the field's entire explicit ACL. */
+    entries?: FieldAccessControlEntry[] | undefined;
+
+    
+    
+    constructor(data?: ISetFieldAccessControlRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entries"])) {
+                this.entries = [] as any;
+                for (let item of _data["entries"])
+                    this.entries!.push(FieldAccessControlEntry.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): SetFieldAccessControlRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new SetFieldAccessControlRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entries)) {
+            data["entries"] = [];
+            for (let item of this.entries)
+                data["entries"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+/** Request body for replacing a template field definition's access control list. The supplied entries fully replace the field's existing explicit ACL. Inherited entries are not accepted. */
+export interface ISetFieldAccessControlRequest {
+    /** The access control entries to set. Replaces the field's entire explicit ACL. */
+    entries?: FieldAccessControlEntry[] | undefined;
+}
+
+/** A trustee's rights to a template field definition. Depending on the aclOnly option on the request, these are either the effective rights (the net result after group membership, allow/deny resolution, and the repository's privilege overlay) or the rights granted by the field's access control list alone. */
+export class FieldRights implements IFieldRights {
+    /** The rights granted to the trustee on the field. */
+    rights?: FieldRight[] | undefined;
+    /** True when the session is read-only, so no write operations are possible regardless of
+the granted rights. */
+    isReadOnly?: boolean;
+
+    
+    
+    constructor(data?: IFieldRights) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["rights"])) {
+                this.rights = [] as any;
+                for (let item of _data["rights"])
+                    this.rights!.push(item);
+            }
+            this.isReadOnly = _data["isReadOnly"];
+        }
+    }
+
+    static fromJS(data: any): FieldRights {
+        data = typeof data === 'object' ? data : {};
+        let result = new FieldRights();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.rights)) {
+            data["rights"] = [];
+            for (let item of this.rights)
+                data["rights"].push(item);
+        }
+        data["isReadOnly"] = this.isReadOnly;
+        return data;
+    }
+}
+
+/** A trustee's rights to a template field definition. Depending on the aclOnly option on the request, these are either the effective rights (the net result after group membership, allow/deny resolution, and the repository's privilege overlay) or the rights granted by the field's access control list alone. */
+export interface IFieldRights {
+    /** The rights granted to the trustee on the field. */
+    rights?: FieldRight[] | undefined;
+    /** True when the session is read-only, so no write operations are possible regardless of
+the granted rights. */
+    isReadOnly?: boolean;
 }
 
 /** Response containing a collection of LinkDefinition. */
@@ -17267,96 +18801,6 @@ returned by GET but are ignored on input (the set operation manages explicit ACE
     inheritedFrom?: string | undefined;
 }
 
-/** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
-export class TrusteeIdentity implements ITrusteeIdentity {
-    /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
-the canonical, stable id for a trustee. On input it is preferred and takes precedence over
-AccountName; always populated on output. */
-    sid?: string | undefined;
-    /** The trustee's account name. On input it may be supplied instead of Sid to
-address the trustee by name (resolved to a SID server-side); the SID wins when both are
-given. Always populated on output. */
-    accountName?: string | undefined;
-    /** The trustee type: one of LaserficheUser, LaserficheGroup,
-WindowsAccount, LdapAccount, LfdsAccount. */
-    trusteeType?: string | undefined;
-    /** True when the trustee is an individual user; false when it is a group. */
-    isUser?: boolean;
-    /** A human-readable display name. Populated by trustee-lookup results; omitted in
-access-control-entry contexts. */
-    displayName?: string | undefined;
-    /** True when the trustee account is disabled. Populated by trustee-lookup results. */
-    isDisabled?: boolean;
-
-    
-    
-    constructor(data?: ITrusteeIdentity) {
-        if (data) {
-            for (var property in data) {
-                if (data.hasOwnProperty(property))
-                    (<any>this)[property] = (<any>data)[property];
-            }
-        }
-    }
-
-    init(_data?: any) {
-        if (_data) {
-            this.sid = _data["sid"];
-            this.accountName = _data["accountName"];
-            this.trusteeType = _data["trusteeType"];
-            this.isUser = _data["isUser"];
-            this.displayName = _data["displayName"];
-            this.isDisabled = _data["isDisabled"];
-        }
-    }
-
-    static fromJS(data: any): TrusteeIdentity {
-        data = typeof data === 'object' ? data : {};
-        let result = new TrusteeIdentity();
-        result.init(data);
-        return result;
-    }
-
-    toJSON(data?: any) {
-        data = typeof data === 'object' ? data : {};
-        data["sid"] = this.sid;
-        data["accountName"] = this.accountName;
-        data["trusteeType"] = this.trusteeType;
-        data["isUser"] = this.isUser;
-        data["displayName"] = this.displayName;
-        data["isDisabled"] = this.isDisabled;
-        return data;
-    }
-}
-
-/** Identifies a security trustee (a user or a group) referenced by an access control entry, an effective-rights query, or a trustee-lookup result. */
-export interface ITrusteeIdentity {
-    /** The trustee's security identifier (an SDDL string such as S-1-5-21-...). This is
-the canonical, stable id for a trustee. On input it is preferred and takes precedence over
-AccountName; always populated on output. */
-    sid?: string | undefined;
-    /** The trustee's account name. On input it may be supplied instead of Sid to
-address the trustee by name (resolved to a SID server-side); the SID wins when both are
-given. Always populated on output. */
-    accountName?: string | undefined;
-    /** The trustee type: one of LaserficheUser, LaserficheGroup,
-WindowsAccount, LdapAccount, LfdsAccount. */
-    trusteeType?: string | undefined;
-    /** True when the trustee is an individual user; false when it is a group. */
-    isUser?: boolean;
-    /** A human-readable display name. Populated by trustee-lookup results; omitted in
-access-control-entry contexts. */
-    displayName?: string | undefined;
-    /** True when the trustee account is disabled. Populated by trustee-lookup results. */
-    isDisabled?: boolean;
-}
-
-/** Whether an access control entry (ACE) grants or denies its rights. Serialized by name. */
-export enum AccessControlType {
-    Allow = "Allow",
-    Deny = "Deny",
-}
-
 /** An individual access right that can be granted to or denied a trustee on an entry. Serialized by name; emitted as a string enum in the OpenAPI schema so clients can reference it directly. */
 export enum EntryRight {
     Browse = "Browse",
@@ -17616,6 +19060,90 @@ export interface IRepository {
     name?: string | undefined;
     /** The corresponding repository Web Client url. */
     webClientUrl?: string | undefined;
+}
+
+/** The current session's rights in a repository: the privileges and feature rights held by the session, plus whether the session is read-only. Reported as named booleans (each map is keyed by the right's name with a granted true/false) rather than a raw bitmask, for UI enablement and pre-flight checks. Reflects the current session only — per-trustee privilege administration is not part of this surface. */
+export class SessionRights implements ISessionRights {
+    /** The session's privileges, keyed by privilege name (e.g. EntryAccess,
+RecordManager), with the value indicating whether the session holds that privilege. */
+    privileges?: { [key: string]: boolean; } | undefined;
+    /** The session's feature rights, keyed by feature-right name (e.g. Search,
+Import), with the value indicating whether the session holds that feature right. */
+    featureRights?: { [key: string]: boolean; } | undefined;
+    /** True when the current session is read-only, so no write operations are possible regardless
+of the granted privileges or feature rights. */
+    isReadOnly?: boolean;
+
+    
+    
+    constructor(data?: ISessionRights) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (_data["privileges"]) {
+                this.privileges = {} as any;
+                for (let key in _data["privileges"]) {
+                    if (_data["privileges"].hasOwnProperty(key))
+                        (<any>this.privileges)![key] = _data["privileges"][key];
+                }
+            }
+            if (_data["featureRights"]) {
+                this.featureRights = {} as any;
+                for (let key in _data["featureRights"]) {
+                    if (_data["featureRights"].hasOwnProperty(key))
+                        (<any>this.featureRights)![key] = _data["featureRights"][key];
+                }
+            }
+            this.isReadOnly = _data["isReadOnly"];
+        }
+    }
+
+    static fromJS(data: any): SessionRights {
+        data = typeof data === 'object' ? data : {};
+        let result = new SessionRights();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (this.privileges) {
+            data["privileges"] = {};
+            for (let key in this.privileges) {
+                if (this.privileges.hasOwnProperty(key))
+                    (<any>data["privileges"])[key] = (<any>this.privileges)[key];
+            }
+        }
+        if (this.featureRights) {
+            data["featureRights"] = {};
+            for (let key in this.featureRights) {
+                if (this.featureRights.hasOwnProperty(key))
+                    (<any>data["featureRights"])[key] = (<any>this.featureRights)[key];
+            }
+        }
+        data["isReadOnly"] = this.isReadOnly;
+        return data;
+    }
+}
+
+/** The current session's rights in a repository: the privileges and feature rights held by the session, plus whether the session is read-only. Reported as named booleans (each map is keyed by the right's name with a granted true/false) rather than a raw bitmask, for UI enablement and pre-flight checks. Reflects the current session only — per-trustee privilege administration is not part of this surface. */
+export interface ISessionRights {
+    /** The session's privileges, keyed by privilege name (e.g. EntryAccess,
+RecordManager), with the value indicating whether the session holds that privilege. */
+    privileges?: { [key: string]: boolean; } | undefined;
+    /** The session's feature rights, keyed by feature-right name (e.g. Search,
+Import), with the value indicating whether the session holds that feature right. */
+    featureRights?: { [key: string]: boolean; } | undefined;
+    /** True when the current session is read-only, so no write operations are possible regardless
+of the granted privileges or feature rights. */
+    isReadOnly?: boolean;
 }
 
 /** Request body for starting an asynchronous search entry task. */
@@ -19111,6 +20639,490 @@ export interface IMoveTemplateFieldRequest {
     /** The 1-based target position. Required. Values less than 1 or greater than the
 current field count are rejected with 400. */
     newPosition: number;
+}
+
+/** The access control list (ACL) of a template definition: its access control entries. Template ACLs have no parent inheritance, so there is no inherit-parents flag. */
+export class TemplateAccessControlList implements ITemplateAccessControlList {
+    /** The access control entries that make up the ACL. */
+    entries?: TemplateAccessControlEntry[] | undefined;
+
+    
+    
+    constructor(data?: ITemplateAccessControlList) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entries"])) {
+                this.entries = [] as any;
+                for (let item of _data["entries"])
+                    this.entries!.push(TemplateAccessControlEntry.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): TemplateAccessControlList {
+        data = typeof data === 'object' ? data : {};
+        let result = new TemplateAccessControlList();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entries)) {
+            data["entries"] = [];
+            for (let item of this.entries)
+                data["entries"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+/** The access control list (ACL) of a template definition: its access control entries. Template ACLs have no parent inheritance, so there is no inherit-parents flag. */
+export interface ITemplateAccessControlList {
+    /** The access control entries that make up the ACL. */
+    entries?: TemplateAccessControlEntry[] | undefined;
+}
+
+/** A single access control entry (ACE) on a template definition: one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. Unlike entry ACEs, template ACEs have no scope and are never inherited. */
+export class TemplateAccessControlEntry implements ITemplateAccessControlEntry {
+    /** The trustee this ACE applies to. On input, identify the trustee by either
+trustee.sid or trustee.accountName (the SID takes precedence when both are given). */
+    trustee?: TrusteeIdentity | undefined;
+    /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. Required on
+input — a missing value is rejected (it must not silently default to Allow). */
+    accessControlType?: AccessControlType | undefined;
+    /** The rights granted or denied by this ACE. */
+    rights?: TemplateRight[] | undefined;
+    /** True when this ACE is inherited. Always false for template ACEs (template definitions have
+no ACL inheritance); returned for contract symmetry and ignored on input. */
+    isInherited?: boolean;
+    /** When inherited, a description of where the ACE was inherited from. Output only; null for
+template ACEs. */
+    inheritedFrom?: string | undefined;
+
+    
+    
+    constructor(data?: ITemplateAccessControlEntry) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.trustee = _data["trustee"] ? TrusteeIdentity.fromJS(_data["trustee"]) : <any>undefined;
+            this.accessControlType = _data["accessControlType"];
+            if (Array.isArray(_data["rights"])) {
+                this.rights = [] as any;
+                for (let item of _data["rights"])
+                    this.rights!.push(item);
+            }
+            this.isInherited = _data["isInherited"];
+            this.inheritedFrom = _data["inheritedFrom"];
+        }
+    }
+
+    static fromJS(data: any): TemplateAccessControlEntry {
+        data = typeof data === 'object' ? data : {};
+        let result = new TemplateAccessControlEntry();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["trustee"] = this.trustee ? this.trustee.toJSON() : <any>undefined;
+        data["accessControlType"] = this.accessControlType;
+        if (Array.isArray(this.rights)) {
+            data["rights"] = [];
+            for (let item of this.rights)
+                data["rights"].push(item);
+        }
+        data["isInherited"] = this.isInherited;
+        data["inheritedFrom"] = this.inheritedFrom;
+        return data;
+    }
+}
+
+/** A single access control entry (ACE) on a template definition: one trustee, whether its rights are allowed or denied, and the rights themselves. A trustee that has both allowed and denied rights is represented as two ACEs. Unlike entry ACEs, template ACEs have no scope and are never inherited. */
+export interface ITemplateAccessControlEntry {
+    /** The trustee this ACE applies to. On input, identify the trustee by either
+trustee.sid or trustee.accountName (the SID takes precedence when both are given). */
+    trustee?: TrusteeIdentity | undefined;
+    /** Whether the ACE grants (Allow) or denies (Deny) the listed rights. Required on
+input — a missing value is rejected (it must not silently default to Allow). */
+    accessControlType?: AccessControlType | undefined;
+    /** The rights granted or denied by this ACE. */
+    rights?: TemplateRight[] | undefined;
+    /** True when this ACE is inherited. Always false for template ACEs (template definitions have
+no ACL inheritance); returned for contract symmetry and ignored on input. */
+    isInherited?: boolean;
+    /** When inherited, a description of where the ACE was inherited from. Output only; null for
+template ACEs. */
+    inheritedFrom?: string | undefined;
+}
+
+/** An individual access right that can be granted to or denied a trustee on a template definition. Serialized by name; emitted as a string enum in the OpenAPI schema so clients can reference it directly. */
+export enum TemplateRight {
+    ReadDefinition = "ReadDefinition",
+    Modify = "Modify",
+    Delete = "Delete",
+    ReadPermissions = "ReadPermissions",
+    ChangePermissions = "ChangePermissions",
+    TakeOwnership = "TakeOwnership",
+}
+
+/** Request body for replacing a template definition's access control list. The supplied entries fully replace the template's existing explicit ACL. Inherited entries are not accepted. */
+export class SetTemplateAccessControlRequest implements ISetTemplateAccessControlRequest {
+    /** The access control entries to set. Replaces the template's entire explicit ACL. */
+    entries?: TemplateAccessControlEntry[] | undefined;
+
+    
+    
+    constructor(data?: ISetTemplateAccessControlRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entries"])) {
+                this.entries = [] as any;
+                for (let item of _data["entries"])
+                    this.entries!.push(TemplateAccessControlEntry.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): SetTemplateAccessControlRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new SetTemplateAccessControlRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entries)) {
+            data["entries"] = [];
+            for (let item of this.entries)
+                data["entries"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+/** Request body for replacing a template definition's access control list. The supplied entries fully replace the template's existing explicit ACL. Inherited entries are not accepted. */
+export interface ISetTemplateAccessControlRequest {
+    /** The access control entries to set. Replaces the template's entire explicit ACL. */
+    entries?: TemplateAccessControlEntry[] | undefined;
+}
+
+/** A trustee's rights to a template definition. Depending on the aclOnly option on the request, these are either the effective rights (the net result after group membership, allow/deny resolution, and the repository's privilege overlay) or the rights granted by the template's access control list alone. */
+export class TemplateRights implements ITemplateRights {
+    /** The rights granted to the trustee on the template. */
+    rights?: TemplateRight[] | undefined;
+    /** True when the session is read-only, so no write operations are possible regardless of
+the granted rights. */
+    isReadOnly?: boolean;
+
+    
+    
+    constructor(data?: ITemplateRights) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["rights"])) {
+                this.rights = [] as any;
+                for (let item of _data["rights"])
+                    this.rights!.push(item);
+            }
+            this.isReadOnly = _data["isReadOnly"];
+        }
+    }
+
+    static fromJS(data: any): TemplateRights {
+        data = typeof data === 'object' ? data : {};
+        let result = new TemplateRights();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.rights)) {
+            data["rights"] = [];
+            for (let item of this.rights)
+                data["rights"].push(item);
+        }
+        data["isReadOnly"] = this.isReadOnly;
+        return data;
+    }
+}
+
+/** A trustee's rights to a template definition. Depending on the aclOnly option on the request, these are either the effective rights (the net result after group membership, allow/deny resolution, and the repository's privilege overlay) or the rights granted by the template's access control list alone. */
+export interface ITemplateRights {
+    /** The rights granted to the trustee on the template. */
+    rights?: TemplateRight[] | undefined;
+    /** True when the session is read-only, so no write operations are possible regardless of
+the granted rights. */
+    isReadOnly?: boolean;
+}
+
+/** The effective account security that applies when a trustee logs in to a repository: the privileges and feature rights the trustee holds, the security tags assigned to it, the audit classes configured for it, and whether the trustee is read-only. Privileges, feature rights, and audit masks are reported as named booleans (each map keyed by the right's name with a granted true/false) rather than raw bitmasks. This is a documented best-effort computation: in rare cases it can differ from the trustee's real rights. The authoritative way to determine a trustee's security is to sign in as that trustee and read the resulting session's rights. Values reflect effective (not direct) security. */
+export class TrusteeEffectiveSecurity implements ITrusteeEffectiveSecurity {
+    /** The trustee's privileges, keyed by privilege name (e.g. EntryAccess,
+RecordManager), with the value indicating whether the trustee holds that privilege. */
+    privileges?: { [key: string]: boolean; } | undefined;
+    /** The trustee's feature rights, keyed by feature-right name (e.g. Search,
+Import), with the value indicating whether the trustee holds that feature right. */
+    featureRights?: { [key: string]: boolean; } | undefined;
+    /** True when the trustee is read-only, so no write operations are possible regardless of the
+granted privileges or feature rights. */
+    isReadOnly?: boolean;
+    /** The security tags assigned to the trustee. */
+    tags?: TrusteeTag[] | undefined;
+    /** The audit classes configured for the trustee, split into successful- and failed-operation
+masks. Each map is keyed by audit-class name with the value indicating whether that class is
+audited. */
+    auditMasks?: TrusteeAuditMasks | undefined;
+
+    
+    
+    constructor(data?: ITrusteeEffectiveSecurity) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (_data["privileges"]) {
+                this.privileges = {} as any;
+                for (let key in _data["privileges"]) {
+                    if (_data["privileges"].hasOwnProperty(key))
+                        (<any>this.privileges)![key] = _data["privileges"][key];
+                }
+            }
+            if (_data["featureRights"]) {
+                this.featureRights = {} as any;
+                for (let key in _data["featureRights"]) {
+                    if (_data["featureRights"].hasOwnProperty(key))
+                        (<any>this.featureRights)![key] = _data["featureRights"][key];
+                }
+            }
+            this.isReadOnly = _data["isReadOnly"];
+            if (Array.isArray(_data["tags"])) {
+                this.tags = [] as any;
+                for (let item of _data["tags"])
+                    this.tags!.push(TrusteeTag.fromJS(item));
+            }
+            this.auditMasks = _data["auditMasks"] ? TrusteeAuditMasks.fromJS(_data["auditMasks"]) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): TrusteeEffectiveSecurity {
+        data = typeof data === 'object' ? data : {};
+        let result = new TrusteeEffectiveSecurity();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (this.privileges) {
+            data["privileges"] = {};
+            for (let key in this.privileges) {
+                if (this.privileges.hasOwnProperty(key))
+                    (<any>data["privileges"])[key] = (<any>this.privileges)[key];
+            }
+        }
+        if (this.featureRights) {
+            data["featureRights"] = {};
+            for (let key in this.featureRights) {
+                if (this.featureRights.hasOwnProperty(key))
+                    (<any>data["featureRights"])[key] = (<any>this.featureRights)[key];
+            }
+        }
+        data["isReadOnly"] = this.isReadOnly;
+        if (Array.isArray(this.tags)) {
+            data["tags"] = [];
+            for (let item of this.tags)
+                data["tags"].push(item.toJSON());
+        }
+        data["auditMasks"] = this.auditMasks ? this.auditMasks.toJSON() : <any>undefined;
+        return data;
+    }
+}
+
+/** The effective account security that applies when a trustee logs in to a repository: the privileges and feature rights the trustee holds, the security tags assigned to it, the audit classes configured for it, and whether the trustee is read-only. Privileges, feature rights, and audit masks are reported as named booleans (each map keyed by the right's name with a granted true/false) rather than raw bitmasks. This is a documented best-effort computation: in rare cases it can differ from the trustee's real rights. The authoritative way to determine a trustee's security is to sign in as that trustee and read the resulting session's rights. Values reflect effective (not direct) security. */
+export interface ITrusteeEffectiveSecurity {
+    /** The trustee's privileges, keyed by privilege name (e.g. EntryAccess,
+RecordManager), with the value indicating whether the trustee holds that privilege. */
+    privileges?: { [key: string]: boolean; } | undefined;
+    /** The trustee's feature rights, keyed by feature-right name (e.g. Search,
+Import), with the value indicating whether the trustee holds that feature right. */
+    featureRights?: { [key: string]: boolean; } | undefined;
+    /** True when the trustee is read-only, so no write operations are possible regardless of the
+granted privileges or feature rights. */
+    isReadOnly?: boolean;
+    /** The security tags assigned to the trustee. */
+    tags?: TrusteeTag[] | undefined;
+    /** The audit classes configured for the trustee, split into successful- and failed-operation
+masks. Each map is keyed by audit-class name with the value indicating whether that class is
+audited. */
+    auditMasks?: TrusteeAuditMasks | undefined;
+}
+
+/** A security tag assigned to a trustee. */
+export class TrusteeTag implements ITrusteeTag {
+    /** The tag's ID. */
+    id?: number;
+    /** The tag's name. */
+    name?: string | undefined;
+    /** True when the tag is a security tag. */
+    isSecure?: boolean;
+
+    
+    
+    constructor(data?: ITrusteeTag) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.isSecure = _data["isSecure"];
+        }
+    }
+
+    static fromJS(data: any): TrusteeTag {
+        data = typeof data === 'object' ? data : {};
+        let result = new TrusteeTag();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["isSecure"] = this.isSecure;
+        return data;
+    }
+}
+
+/** A security tag assigned to a trustee. */
+export interface ITrusteeTag {
+    /** The tag's ID. */
+    id?: number;
+    /** The tag's name. */
+    name?: string | undefined;
+    /** True when the tag is a security tag. */
+    isSecure?: boolean;
+}
+
+/** The audit classes configured for a trustee, split by operation outcome. */
+export class TrusteeAuditMasks implements ITrusteeAuditMasks {
+    /** Audit classes audited on successful operations, keyed by audit-class name. */
+    success?: { [key: string]: boolean; } | undefined;
+    /** Audit classes audited on failed operations, keyed by audit-class name. */
+    failure?: { [key: string]: boolean; } | undefined;
+
+    
+    
+    constructor(data?: ITrusteeAuditMasks) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (_data["success"]) {
+                this.success = {} as any;
+                for (let key in _data["success"]) {
+                    if (_data["success"].hasOwnProperty(key))
+                        (<any>this.success)![key] = _data["success"][key];
+                }
+            }
+            if (_data["failure"]) {
+                this.failure = {} as any;
+                for (let key in _data["failure"]) {
+                    if (_data["failure"].hasOwnProperty(key))
+                        (<any>this.failure)![key] = _data["failure"][key];
+                }
+            }
+        }
+    }
+
+    static fromJS(data: any): TrusteeAuditMasks {
+        data = typeof data === 'object' ? data : {};
+        let result = new TrusteeAuditMasks();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (this.success) {
+            data["success"] = {};
+            for (let key in this.success) {
+                if (this.success.hasOwnProperty(key))
+                    (<any>data["success"])[key] = (<any>this.success)[key];
+            }
+        }
+        if (this.failure) {
+            data["failure"] = {};
+            for (let key in this.failure) {
+                if (this.failure.hasOwnProperty(key))
+                    (<any>data["failure"])[key] = (<any>this.failure)[key];
+            }
+        }
+        return data;
+    }
+}
+
+/** The audit classes configured for a trustee, split by operation outcome. */
+export interface ITrusteeAuditMasks {
+    /** Audit classes audited on successful operations, keyed by audit-class name. */
+    success?: { [key: string]: boolean; } | undefined;
+    /** Audit classes audited on failed operations, keyed by audit-class name. */
+    failure?: { [key: string]: boolean; } | undefined;
 }
 
 export interface FileParameter {

--- a/packages/lf-repository-api-client-v2/test/AccessRights/EntryAccessControl.test.ts
+++ b/packages/lf-repository-api-client-v2/test/AccessRights/EntryAccessControl.test.ts
@@ -12,8 +12,8 @@ import {
 } from '../../index.js';
 
 // Parallel (JS) coverage for the V2 entry access-rights endpoints (PRD 6.4.A — REQ-ACCESS-001):
-// getEntryAccessControl, setEntryAccessControl, getEntryEffectiveRights, getEntryDirectRights
-// (REQ-ACCESS-006), and the Trustees lookupTrustees search. The dotnet REST integration suite owns
+// getEntryAccessControl (incl. includeInherited filter), setEntryAccessControl, getEntryRights
+// (effective and aclOnly — REQ-ACCESS-006), and the Trustees lookupTrustees search. The dotnet REST integration suite owns
 // the exhaustive contract; these
 // exercise the JS client end-to-end against a running server. No multipart upload here, so they
 // run under both vitest+node and vitest+jsdom.
@@ -73,18 +73,18 @@ describe('Entry Access Rights (REQ-ACCESS-001)', () => {
     }
   });
 
-  test('getEntryEffectiveRights for the calling session includes Browse and Read', async () => {
+  test('getEntryRights for the calling session includes Browse and Read', async () => {
     const entryId = await createFolder();
-    const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({ repositoryId, entryId });
+    const rights = await _RepositoryApiClient.entriesClient.getEntryRights({ repositoryId, entryId });
     expect(rights.rights).toBeDefined();
     expect(rights.rights).toContain(EntryRight.Browse);
     expect(rights.rights).toContain(EntryRight.Read);
   });
 
-  test('getEntryEffectiveRights resolves for a specific trustee by SID', async () => {
+  test('getEntryRights resolves for a specific trustee by SID', async () => {
     const entryId = await createFolder();
     const trustee = await getAnyTrustee(entryId);
-    const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({
+    const rights = await _RepositoryApiClient.entriesClient.getEntryRights({
       repositoryId,
       entryId,
       trusteeId: trustee.sid,
@@ -93,13 +93,13 @@ describe('Entry Access Rights (REQ-ACCESS-001)', () => {
     expect(rights.rights).toBeDefined();
   });
 
-  test('getEntryEffectiveRights resolves a trustee addressed by account name', async () => {
+  test('getEntryRights resolves a trustee addressed by account name', async () => {
     const entryId = await createFolder();
     const trustee = await getAnyTrustee(entryId);
     if (!trustee.accountName) {
       return; // borrowed trustee has no account name to resolve by
     }
-    const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({
+    const rights = await _RepositoryApiClient.entriesClient.getEntryRights({
       repositoryId,
       entryId,
       trusteeName: trustee.accountName,
@@ -108,39 +108,55 @@ describe('Entry Access Rights (REQ-ACCESS-001)', () => {
     expect(rights.rights).toBeDefined();
   });
 
-  test('getEntryDirectRights for the calling session includes Browse and Read', async () => {
+  test('getEntryRights with aclOnly for the calling session includes Browse and Read', async () => {
     const entryId = await createFolder();
-    const rights = await _RepositoryApiClient.entriesClient.getEntryDirectRights({ repositoryId, entryId });
+    const rights = await _RepositoryApiClient.entriesClient.getEntryRights({ repositoryId, entryId, aclOnly: true });
     expect(rights.rights).toBeDefined();
     expect(rights.rights).toContain(EntryRight.Browse);
     expect(rights.rights).toContain(EntryRight.Read);
   });
 
-  test('getEntryDirectRights resolves for a specific trustee by SID', async () => {
+  test('getEntryRights with aclOnly resolves for a specific trustee by SID', async () => {
     const entryId = await createFolder();
     const trustee = await getAnyTrustee(entryId);
-    const rights = await _RepositoryApiClient.entriesClient.getEntryDirectRights({
+    const rights = await _RepositoryApiClient.entriesClient.getEntryRights({
       repositoryId,
       entryId,
       trusteeId: trustee.sid,
+      aclOnly: true,
     });
     expect(rights).not.toBeNull();
     expect(rights.rights).toBeDefined();
   });
 
-  test('getEntryDirectRights resolves a trustee addressed by account name', async () => {
+  test('getEntryRights with aclOnly resolves a trustee addressed by account name', async () => {
     const entryId = await createFolder();
     const trustee = await getAnyTrustee(entryId);
     if (!trustee.accountName) {
       return; // borrowed trustee has no account name to resolve by
     }
-    const rights = await _RepositoryApiClient.entriesClient.getEntryDirectRights({
+    const rights = await _RepositoryApiClient.entriesClient.getEntryRights({
       repositoryId,
       entryId,
       trusteeName: trustee.accountName,
+      aclOnly: true,
     });
     expect(rights).not.toBeNull();
     expect(rights.rights).toBeDefined();
+  });
+
+  test('getEntryAccessControl with includeInherited=false returns only explicit ACEs', async () => {
+    const entryId = await createFolder();
+    const all = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId });
+    const explicitOnly = await _RepositoryApiClient.entriesClient.getEntryAccessControl({
+      repositoryId,
+      entryId,
+      includeInherited: false,
+    });
+    expect(explicitOnly.entries).toBeDefined();
+    expect(explicitOnly.entries!.every((e) => !e.isInherited)).toBe(true);
+    expect(explicitOnly.entries!.length).toBeLessThanOrEqual(all.entries!.length);
+    expect(explicitOnly.inheritParents).toBe(all.inheritParents);
   });
 
   test('setEntryAccessControl full replace persists on an independent re-fetch', async () => {

--- a/packages/lf-repository-api-client-v2/test/AccessRights/EntryAccessControl.test.ts
+++ b/packages/lf-repository-api-client-v2/test/AccessRights/EntryAccessControl.test.ts
@@ -12,8 +12,9 @@ import {
 } from '../../index.js';
 
 // Parallel (JS) coverage for the V2 entry access-rights endpoints (PRD 6.4.A — REQ-ACCESS-001):
-// getEntryAccessControl, setEntryAccessControl, getEntryEffectiveRights, and the Trustees
-// lookupTrustees search. The dotnet REST integration suite owns the exhaustive contract; these
+// getEntryAccessControl, setEntryAccessControl, getEntryEffectiveRights, getEntryDirectRights
+// (REQ-ACCESS-006), and the Trustees lookupTrustees search. The dotnet REST integration suite owns
+// the exhaustive contract; these
 // exercise the JS client end-to-end against a running server. No multipart upload here, so they
 // run under both vitest+node and vitest+jsdom.
 //
@@ -99,6 +100,41 @@ describe('Entry Access Rights (REQ-ACCESS-001)', () => {
       return; // borrowed trustee has no account name to resolve by
     }
     const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({
+      repositoryId,
+      entryId,
+      trusteeName: trustee.accountName,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('getEntryDirectRights for the calling session includes Browse and Read', async () => {
+    const entryId = await createFolder();
+    const rights = await _RepositoryApiClient.entriesClient.getEntryDirectRights({ repositoryId, entryId });
+    expect(rights.rights).toBeDefined();
+    expect(rights.rights).toContain(EntryRight.Browse);
+    expect(rights.rights).toContain(EntryRight.Read);
+  });
+
+  test('getEntryDirectRights resolves for a specific trustee by SID', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+    const rights = await _RepositoryApiClient.entriesClient.getEntryDirectRights({
+      repositoryId,
+      entryId,
+      trusteeId: trustee.sid,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('getEntryDirectRights resolves a trustee addressed by account name', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+    if (!trustee.accountName) {
+      return; // borrowed trustee has no account name to resolve by
+    }
+    const rights = await _RepositoryApiClient.entriesClient.getEntryDirectRights({
       repositoryId,
       entryId,
       trusteeName: trustee.accountName,

--- a/packages/lf-repository-api-client-v2/test/AccessRights/EntryAccessControl.test.ts
+++ b/packages/lf-repository-api-client-v2/test/AccessRights/EntryAccessControl.test.ts
@@ -1,0 +1,223 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId, _RepositoryApiClient } from '../CreateSession.js';
+import { CreateEntry, deleteEntry } from '../BaseTest.js';
+import {
+  AccessControlEntry,
+  AccessControlType,
+  EntryAccessScope,
+  EntryRight,
+  SetAccessControlRequest,
+  TrusteeIdentity,
+} from '../../index.js';
+
+// Parallel (JS) coverage for the V2 entry access-rights endpoints (PRD 6.4.A — REQ-ACCESS-001):
+// getEntryAccessControl, setEntryAccessControl, getEntryEffectiveRights, and the Trustees
+// lookupTrustees search. The dotnet REST integration suite owns the exhaustive contract; these
+// exercise the JS client end-to-end against a running server. No multipart upload here, so they
+// run under both vitest+node and vitest+jsdom.
+//
+// Each test creates its OWN folder (autoRename) and derives any trustee SID it needs at runtime
+// from the repository's own ACLs — no hard-coded SIDs. afterEach restores an inheriting,
+// explicit-ACE-free ACL before deleting, so a Deny-Delete ACE can never leave the folder
+// undeletable (the lesson the dotnet suite's shared-folder isolation bug taught us).
+describe('Entry Access Rights (REQ-ACCESS-001)', () => {
+  let createdEntryId: number | undefined;
+
+  afterEach(async () => {
+    if (createdEntryId !== undefined) {
+      const entryId = createdEntryId;
+      createdEntryId = undefined;
+      try {
+        await _RepositoryApiClient.entriesClient.setEntryAccessControl({
+          repositoryId,
+          entryId,
+          request: new SetAccessControlRequest({ inheritParents: true, entries: [] }),
+        });
+      } catch {
+        /* folder may already be gone, or caller may lack permission — fall through to delete */
+      }
+      try {
+        await deleteEntry(_RepositoryApiClient, entryId);
+      } catch {
+        /* leftover is harmless */
+      }
+    }
+  });
+
+  async function createFolder(): Promise<number> {
+    const folder = await CreateEntry(_RepositoryApiClient, 'JS AccessRights Test Folder');
+    createdEntryId = folder.id!;
+    return createdEntryId;
+  }
+
+  // Returns a trustee SID present on the entry's ACL (explicit or inherited). Every entry inherits
+  // at least the administrative ACEs, so this reliably yields a real, resolvable SID.
+  async function getAnyTrustee(entryId: number): Promise<TrusteeIdentity> {
+    const acl = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId });
+    const trustee = acl.entries?.map((e) => e.trustee).find((t) => !!t?.sid);
+    expect(trustee).toBeDefined();
+    return trustee!;
+  }
+
+  test('getEntryAccessControl returns an ACL whose ACEs carry typed trustees', async () => {
+    const entryId = await createFolder();
+    const acl = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId });
+    expect(acl).not.toBeNull();
+    expect(acl.entries).toBeDefined();
+    expect(acl.entries!.length).toBeGreaterThan(0);
+    for (const ace of acl.entries!) {
+      expect(ace.trustee).toBeDefined();
+      expect(ace.trustee!.sid).toBeTruthy();
+    }
+  });
+
+  test('getEntryEffectiveRights for the calling session includes Browse and Read', async () => {
+    const entryId = await createFolder();
+    const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({ repositoryId, entryId });
+    expect(rights.rights).toBeDefined();
+    expect(rights.rights).toContain(EntryRight.Browse);
+    expect(rights.rights).toContain(EntryRight.Read);
+  });
+
+  test('getEntryEffectiveRights resolves for a specific trustee by SID', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+    const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({
+      repositoryId,
+      entryId,
+      trusteeId: trustee.sid,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('getEntryEffectiveRights resolves a trustee addressed by account name', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+    if (!trustee.accountName) {
+      return; // borrowed trustee has no account name to resolve by
+    }
+    const rights = await _RepositoryApiClient.entriesClient.getEntryEffectiveRights({
+      repositoryId,
+      entryId,
+      trusteeName: trustee.accountName,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('setEntryAccessControl full replace persists on an independent re-fetch', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+    await _RepositoryApiClient.entriesClient.setEntryAccessControl({
+      repositoryId,
+      entryId,
+      request: new SetAccessControlRequest({
+        inheritParents: true,
+        entries: [
+          new AccessControlEntry({
+            trustee: new TrusteeIdentity({ sid: trustee.sid }),
+            accessControlType: AccessControlType.Allow,
+            rights: [EntryRight.Browse, EntryRight.Read],
+            scope: EntryAccessScope.ThisEntry,
+          }),
+        ],
+      }),
+    });
+
+    // Trap 4: SetAccessControl stages and is persisted via Save(); never trust the mutating call's
+    // own response body — assert via an independent GET.
+    const refreshed = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId });
+    const explicit = refreshed.entries!.find(
+      (e) => !e.isInherited && e.trustee?.sid === trustee.sid && e.accessControlType === AccessControlType.Allow
+    );
+    expect(explicit).toBeDefined();
+    expect(explicit!.rights).toContain(EntryRight.Browse);
+    expect(explicit!.rights).toContain(EntryRight.Read);
+    expect(refreshed.inheritParents).toBe(true);
+  });
+
+  test('setEntryAccessControl with an empty entries list clears explicit ACEs', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+
+    // Seed an explicit ACE.
+    await _RepositoryApiClient.entriesClient.setEntryAccessControl({
+      repositoryId,
+      entryId,
+      request: new SetAccessControlRequest({
+        inheritParents: true,
+        entries: [
+          new AccessControlEntry({
+            trustee: new TrusteeIdentity({ sid: trustee.sid }),
+            accessControlType: AccessControlType.Allow,
+            rights: [EntryRight.Browse],
+            scope: EntryAccessScope.ThisEntry,
+          }),
+        ],
+      }),
+    });
+    const seeded = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId });
+    expect(seeded.entries!.some((e) => !e.isInherited)).toBe(true);
+
+    // An empty entries list with inheritParents=true clears every explicit ACE.
+    await _RepositoryApiClient.entriesClient.setEntryAccessControl({
+      repositoryId,
+      entryId,
+      request: new SetAccessControlRequest({ inheritParents: true, entries: [] }),
+    });
+    const cleared = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId });
+    expect(cleared.entries!.some((e) => !e.isInherited)).toBe(false);
+  });
+
+  test('setEntryAccessControl rejects a blank trustee sid with 400', async () => {
+    const entryId = await createFolder();
+    await expect(
+      _RepositoryApiClient.entriesClient.setEntryAccessControl({
+        repositoryId,
+        entryId,
+        request: new SetAccessControlRequest({
+          inheritParents: true,
+          entries: [
+            new AccessControlEntry({
+              trustee: new TrusteeIdentity({ sid: '' }),
+              accessControlType: AccessControlType.Allow,
+              rights: [EntryRight.Browse],
+              scope: EntryAccessScope.ThisEntry,
+            }),
+          ],
+        }),
+      })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  test('lookupTrustees finds a known trustee', async () => {
+    const entryId = await createFolder();
+    const trustee = await getAnyTrustee(entryId);
+    const accountName = trustee.accountName ?? '';
+    const searchTerm = accountName.includes('\\')
+      ? accountName.substring(accountName.lastIndexOf('\\') + 1)
+      : accountName;
+
+    if (!searchTerm) {
+      // Fall back to a presence check if the trustee has no searchable account name.
+      const any = await _RepositoryApiClient.trusteesClient.lookupTrustees({ repositoryId, search: 'a' });
+      expect(any).toBeDefined();
+      return;
+    }
+
+    const results = await _RepositoryApiClient.trusteesClient.lookupTrustees({ repositoryId, search: searchTerm });
+    expect(results).toBeDefined();
+    expect(results.length).toBeGreaterThan(0);
+    const match = results.find((t) => t.sid === trustee.sid);
+    expect(match).toBeDefined();
+    expect(match!.sid).toBeTruthy();
+  });
+
+  test('lookupTrustees rejects an unrecognized type with 400', async () => {
+    await expect(
+      _RepositoryApiClient.trusteesClient.lookupTrustees({ repositoryId, search: 'a', type: 'bogus' })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/packages/lf-repository-api-client-v2/test/AccessRights/FieldAccessControl.test.ts
+++ b/packages/lf-repository-api-client-v2/test/AccessRights/FieldAccessControl.test.ts
@@ -1,0 +1,137 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId, _RepositoryApiClient } from '../CreateSession.js';
+import {
+  AccessControlType,
+  CreateFieldDefinitionRequest,
+  FieldAccessControlEntry,
+  FieldRight,
+  FieldType,
+  SetFieldAccessControlRequest,
+  TrusteeIdentity,
+} from '../../index.js';
+
+// Parallel (JS) coverage for the V2 field access-rights endpoints (PRD 6.4.B — REQ-ACCESS-002):
+// getFieldAccessControl, setFieldAccessControl, getFieldRights (effective and aclOnly) and the default-field ACL.
+// The dotnet REST integration suite owns the exhaustive contract; these exercise the JS client
+// end-to-end against a running server. No multipart upload, so they run under node and jsdom.
+//
+// Each per-field test creates its OWN throwaway field definition (deleted in afterEach) and borrows
+// a real trustee SID at runtime — no hard-coded SIDs, never mutates a shared fixture.
+describe('Field Access Rights (REQ-ACCESS-002)', () => {
+  let createdFieldId: number | undefined;
+
+  afterEach(async () => {
+    if (createdFieldId !== undefined) {
+      const fieldId = createdFieldId;
+      createdFieldId = undefined;
+      try {
+        await _RepositoryApiClient.fieldDefinitionsClient.deleteFieldDefinition({ repositoryId, fieldId });
+      } catch {
+        /* field may already be gone */
+      }
+    }
+  });
+
+  async function createField(): Promise<number> {
+    const created = await _RepositoryApiClient.fieldDefinitionsClient.createFieldDefinition({
+      repositoryId,
+      request: new CreateFieldDefinitionRequest({ name: `JS_ACL_TEST_FIELD_${Date.now()}`, fieldType: FieldType.String }),
+    });
+    createdFieldId = created.id!;
+    return createdFieldId;
+  }
+
+  // A real, resolvable trustee SID: prefer one off the field's own ACL (the default ACL copied at
+  // creation); fall back to the root entry's ACL.
+  async function getAnyTrustee(fieldId: number): Promise<TrusteeIdentity> {
+    const acl = await _RepositoryApiClient.fieldDefinitionsClient.getFieldAccessControl({ repositoryId, fieldId });
+    const t = acl.entries?.map((e) => e.trustee).find((x) => !!x?.sid);
+    if (t) return t;
+    const entryAcl = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId: 1 });
+    const et = entryAcl.entries?.map((e) => e.trustee).find((x) => !!x?.sid);
+    expect(et).toBeDefined();
+    return new TrusteeIdentity({ sid: et!.sid, accountName: et!.accountName });
+  }
+
+  test('getFieldAccessControl returns an ACL with only explicit (never inherited) ACEs', async () => {
+    const fieldId = await createField();
+    const acl = await _RepositoryApiClient.fieldDefinitionsClient.getFieldAccessControl({ repositoryId, fieldId });
+    expect(acl).not.toBeNull();
+    expect(acl.entries).toBeDefined();
+    for (const ace of acl.entries!) {
+      expect(ace.isInherited).toBeFalsy();
+    }
+  });
+
+  test('getFieldRights for the calling session includes ReadValue', async () => {
+    const fieldId = await createField();
+    const rights = await _RepositoryApiClient.fieldDefinitionsClient.getFieldRights({ repositoryId, fieldId });
+    expect(rights.rights).toBeDefined();
+    expect(rights.rights).toContain(FieldRight.ReadValue);
+  });
+
+  test('getFieldRights resolves for a specific trustee by SID', async () => {
+    const fieldId = await createField();
+    const trustee = await getAnyTrustee(fieldId);
+    const rights = await _RepositoryApiClient.fieldDefinitionsClient.getFieldRights({
+      repositoryId,
+      fieldId,
+      trusteeId: trustee.sid,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('getFieldRights with aclOnly for the calling session includes ReadValue', async () => {
+    const fieldId = await createField();
+    const rights = await _RepositoryApiClient.fieldDefinitionsClient.getFieldRights({ repositoryId, fieldId, aclOnly: true });
+    expect(rights.rights).toBeDefined();
+    expect(rights.rights).toContain(FieldRight.ReadValue);
+  });
+
+  test('getFieldRights with aclOnly resolves for a specific trustee by SID', async () => {
+    const fieldId = await createField();
+    const trustee = await getAnyTrustee(fieldId);
+    const rights = await _RepositoryApiClient.fieldDefinitionsClient.getFieldRights({
+      repositoryId,
+      fieldId,
+      trusteeId: trustee.sid,
+      aclOnly: true,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('setFieldAccessControl full replace persists on an independent re-fetch', async () => {
+    const fieldId = await createField();
+    const trustee = await getAnyTrustee(fieldId);
+    await _RepositoryApiClient.fieldDefinitionsClient.setFieldAccessControl({
+      repositoryId,
+      fieldId,
+      request: new SetFieldAccessControlRequest({
+        entries: [
+          new FieldAccessControlEntry({
+            trustee: new TrusteeIdentity({ sid: trustee.sid }),
+            accessControlType: AccessControlType.Allow,
+            rights: [FieldRight.ReadValue, FieldRight.SetValue],
+          }),
+        ],
+      }),
+    });
+
+    const refreshed = await _RepositoryApiClient.fieldDefinitionsClient.getFieldAccessControl({ repositoryId, fieldId });
+    const explicit = refreshed.entries!.find(
+      (e) => e.trustee?.sid === trustee.sid && e.accessControlType === AccessControlType.Allow
+    );
+    expect(explicit).toBeDefined();
+    expect(explicit!.rights).toContain(FieldRight.ReadValue);
+    expect(explicit!.rights).toContain(FieldRight.SetValue);
+  });
+
+  test('getDefaultFieldAccessControl returns the repository default field ACL', async () => {
+    const acl = await _RepositoryApiClient.fieldDefinitionsClient.getDefaultFieldAccessControl({ repositoryId });
+    expect(acl).not.toBeNull();
+    expect(acl.entries).toBeDefined();
+  });
+});

--- a/packages/lf-repository-api-client-v2/test/AccessRights/SessionRights.test.ts
+++ b/packages/lf-repository-api-client-v2/test/AccessRights/SessionRights.test.ts
@@ -1,0 +1,21 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId, _RepositoryApiClient } from '../CreateSession.js';
+
+// Parallel (JS) coverage for the V2 getSessionRights endpoint (PRD 6.4.B — REQ-ACCESS-004): the
+// current session's effective privileges / feature rights (named-boolean maps) and read-only flag.
+// Read-only and side-effect-free; runs under node and jsdom.
+describe('Session Rights (REQ-ACCESS-004)', () => {
+  test('getSessionRights returns named-boolean privilege and feature-right maps', async () => {
+    const rights = await _RepositoryApiClient.repositoriesClient.getSessionRights({ repositoryId });
+
+    expect(rights).not.toBeNull();
+    expect(rights.privileges).toBeDefined();
+    expect(rights.featureRights).toBeDefined();
+    expect(Object.keys(rights.privileges!).length).toBeGreaterThan(0);
+    expect(Object.keys(rights.featureRights!).length).toBeGreaterThan(0);
+    // The admin session used for tests is read-write and holds at least one privilege.
+    expect(rights.isReadOnly).toBe(false);
+    expect(Object.values(rights.privileges!).some((v) => v === true)).toBe(true);
+  });
+});

--- a/packages/lf-repository-api-client-v2/test/AccessRights/TemplateAccessControl.test.ts
+++ b/packages/lf-repository-api-client-v2/test/AccessRights/TemplateAccessControl.test.ts
@@ -1,0 +1,135 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId, _RepositoryApiClient } from '../CreateSession.js';
+import {
+  AccessControlType,
+  CreateTemplateRequest,
+  SetTemplateAccessControlRequest,
+  TemplateAccessControlEntry,
+  TemplateRight,
+  TrusteeIdentity,
+} from '../../index.js';
+
+// Parallel (JS) coverage for the V2 template access-rights endpoints (PRD 6.4.C — REQ-ACCESS-003):
+// getTemplateAccessControl, setTemplateAccessControl, getTemplateRights (effective and aclOnly) and the
+// default-template ACL. The dotnet REST integration suite owns the exhaustive contract; these
+// exercise the JS client end-to-end against a running server. No multipart upload, so they run
+// under node and jsdom.
+//
+// Each per-template test creates its OWN throwaway template definition (deleted in afterEach) and
+// borrows a real trustee SID at runtime — never targets a shared fixture template.
+describe('Template Access Rights (REQ-ACCESS-003)', () => {
+  let createdTemplateId: number | undefined;
+
+  afterEach(async () => {
+    if (createdTemplateId !== undefined) {
+      const templateId = createdTemplateId;
+      createdTemplateId = undefined;
+      try {
+        await _RepositoryApiClient.templateDefinitionsClient.deleteTemplate({ repositoryId, templateId });
+      } catch {
+        /* template may already be gone */
+      }
+    }
+  });
+
+  async function createTemplate(): Promise<number> {
+    const created = await _RepositoryApiClient.templateDefinitionsClient.createTemplate({
+      repositoryId,
+      request: new CreateTemplateRequest({ name: `JS_ACL_TEST_TEMPLATE_${Date.now()}` }),
+    });
+    createdTemplateId = created.id!;
+    return createdTemplateId;
+  }
+
+  async function getAnyTrustee(templateId: number): Promise<TrusteeIdentity> {
+    const acl = await _RepositoryApiClient.templateDefinitionsClient.getTemplateAccessControl({ repositoryId, templateId });
+    const t = acl.entries?.map((e) => e.trustee).find((x) => !!x?.sid);
+    if (t) return t;
+    const entryAcl = await _RepositoryApiClient.entriesClient.getEntryAccessControl({ repositoryId, entryId: 1 });
+    const et = entryAcl.entries?.map((e) => e.trustee).find((x) => !!x?.sid);
+    expect(et).toBeDefined();
+    return new TrusteeIdentity({ sid: et!.sid, accountName: et!.accountName });
+  }
+
+  test('getTemplateAccessControl returns an ACL with only explicit (never inherited) ACEs', async () => {
+    const templateId = await createTemplate();
+    const acl = await _RepositoryApiClient.templateDefinitionsClient.getTemplateAccessControl({ repositoryId, templateId });
+    expect(acl).not.toBeNull();
+    expect(acl.entries).toBeDefined();
+    for (const ace of acl.entries!) {
+      expect(ace.isInherited).toBeFalsy();
+    }
+  });
+
+  test('getTemplateRights for the calling session includes ReadDefinition', async () => {
+    const templateId = await createTemplate();
+    const rights = await _RepositoryApiClient.templateDefinitionsClient.getTemplateRights({ repositoryId, templateId });
+    expect(rights.rights).toBeDefined();
+    expect(rights.rights).toContain(TemplateRight.ReadDefinition);
+  });
+
+  test('getTemplateRights resolves for a specific trustee by SID', async () => {
+    const templateId = await createTemplate();
+    const trustee = await getAnyTrustee(templateId);
+    const rights = await _RepositoryApiClient.templateDefinitionsClient.getTemplateRights({
+      repositoryId,
+      templateId,
+      trusteeId: trustee.sid,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('getTemplateRights with aclOnly for the calling session includes ReadDefinition', async () => {
+    const templateId = await createTemplate();
+    const rights = await _RepositoryApiClient.templateDefinitionsClient.getTemplateRights({ repositoryId, templateId, aclOnly: true });
+    expect(rights.rights).toBeDefined();
+    expect(rights.rights).toContain(TemplateRight.ReadDefinition);
+  });
+
+  test('getTemplateRights with aclOnly resolves for a specific trustee by SID', async () => {
+    const templateId = await createTemplate();
+    const trustee = await getAnyTrustee(templateId);
+    const rights = await _RepositoryApiClient.templateDefinitionsClient.getTemplateRights({
+      repositoryId,
+      templateId,
+      trusteeId: trustee.sid,
+      aclOnly: true,
+    });
+    expect(rights).not.toBeNull();
+    expect(rights.rights).toBeDefined();
+  });
+
+  test('setTemplateAccessControl full replace persists on an independent re-fetch', async () => {
+    const templateId = await createTemplate();
+    const trustee = await getAnyTrustee(templateId);
+    await _RepositoryApiClient.templateDefinitionsClient.setTemplateAccessControl({
+      repositoryId,
+      templateId,
+      request: new SetTemplateAccessControlRequest({
+        entries: [
+          new TemplateAccessControlEntry({
+            trustee: new TrusteeIdentity({ sid: trustee.sid }),
+            accessControlType: AccessControlType.Allow,
+            rights: [TemplateRight.ReadDefinition, TemplateRight.Modify],
+          }),
+        ],
+      }),
+    });
+
+    const refreshed = await _RepositoryApiClient.templateDefinitionsClient.getTemplateAccessControl({ repositoryId, templateId });
+    const explicit = refreshed.entries!.find(
+      (e) => e.trustee?.sid === trustee.sid && e.accessControlType === AccessControlType.Allow
+    );
+    expect(explicit).toBeDefined();
+    expect(explicit!.rights).toContain(TemplateRight.ReadDefinition);
+    expect(explicit!.rights).toContain(TemplateRight.Modify);
+  });
+
+  test('getDefaultTemplateAccessControl returns the repository default template ACL', async () => {
+    const acl = await _RepositoryApiClient.templateDefinitionsClient.getDefaultTemplateAccessControl({ repositoryId });
+    expect(acl).not.toBeNull();
+    expect(acl.entries).toBeDefined();
+  });
+});


### PR DESCRIPTION
Regenerates the V2 TypeScript client for the PRD 6.4.B/C/D Access Rights endpoints and adds integration tests. Companion to server PR #173272 (stacks on the 6.4.A client work in #54).

**New client surface**
- Field: `getFieldAccessControl` (GET/PUT), `getFieldRights` (returns `FieldRights`; optional `trusteeId`/`trusteeName`/`aclOnly`), default field ACL get/set, `getSessionRights`.
- Template: `getTemplateAccessControl` (GET/PUT), `getTemplateRights` (returns `TemplateRights`; optional `aclOnly`), default template ACL get/set.
- Trustee: `getTrusteeEffectiveSecurity` + TrusteeEffectiveSecurity / TrusteeTag / TrusteeAuditMasks types.

Note: the server collapsed the original separate EffectiveRights + DirectRights routes into a single `Rights` endpoint with an `aclOnly` flag before GA, so the regen exposes one `get{Field,Template}Rights` per resource (not separate effective/direct methods). `aclOnly=false` (default) = effective rights with the privilege overlay; `aclOnly=true` = own-ACL rights without it. Trustee EffectiveSecurity (6.4.D) has no effective/direct pair and is unchanged.

**Validation**: against a local server → dev-CA, AccessRights integration tests pass under both node and jsdom. `pnpm build` (nswag regen from prod swagger + tsc) is clean; baseUrl defaults to the production URL (no localhost baked).

**Notes**: the regen-tooling `download_swagger.py` normalization is intentionally NOT in this PR — it ships separately as `infra/localhost-trap-normalize`. Tracks TFS #673975 / #673976 / #673977 (epic #670528).