### PR TITLE
Regenerate V2 client for 6.5.D Records Management endpoints

### DIFF
--- a/packages/lf-repository-api-client-v2/ClientBase.ts
+++ b/packages/lf-repository-api-client-v2/ClientBase.ts
@@ -25,6 +25,7 @@ export interface IRepositoryApiClient {
   tasksClient: generated.ITasksClient;
   templateDefinitionsClient: ITemplateDefinitionsClient;
   linkDefinitionsClient: ILinkDefinitionsClient;
+  recordsManagementClient: generated.IRecordsManagementClient;
   defaultRequestHeaders: Record<string, string>;
 }
 
@@ -43,6 +44,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
   public tasksClient: generated.ITasksClient;
   public templateDefinitionsClient: ITemplateDefinitionsClient;
   public linkDefinitionsClient: ILinkDefinitionsClient;
+  public recordsManagementClient: generated.IRecordsManagementClient;
 
   private repoClientHandler: RepositoryApiClientHttpHandler;
 
@@ -82,6 +84,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
     this.tasksClient = new generated.TasksClient(this.baseUrl, http);
     this.templateDefinitionsClient = new TemplateDefinitionsClient(this.baseUrl, http);
     this.linkDefinitionsClient = new LinkDefinitionsClient(this.baseUrl, http);
+    this.recordsManagementClient = new generated.RecordsManagementClient(this.baseUrl, http);
   }
 
   /**

--- a/packages/lf-repository-api-client-v2/generate-client/swagger-override.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger-override.json
@@ -112,6 +112,121 @@
             }
           }
         }
+      },
+      "RecordsManagementProperties": {
+        "type": "object",
+        "description": "The records management properties of an entry. This is the abstract base; the concrete shape is\nRecordProperties for a document record (RecordType = Record)\nor RecordFolderProperties for a record folder (RecordFolder). Members\ncommon to both record and record folder live here; type-specific members live on the subtypes.\nMany members are computed by the repository and are read-only \u00e2\u20ac\u201d they are noted as such and are\nignored on update.",
+        "x-abstract": true,
+        "additionalProperties": false,
+        "properties": {
+          "recordType": {
+            "description": "Whether these properties describe a document record or a record folder. Determines the\nconcrete subtype (RecordProperties or RecordFolderProperties)\nand which type-specific members are present.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/RecordEntryType"
+              }
+            ]
+          },
+          "dispositionState": {
+            "description": "The current lifecycle state. Computed (read-only).",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DispositionState"
+              }
+            ]
+          },
+          "isCutoff": {
+            "type": "boolean",
+            "description": "True when the entry has been cut off. Computed (read-only)."
+          },
+          "isEligibleForCutoff": {
+            "type": "boolean",
+            "description": "True when the entry is currently eligible for cutoff. Computed (read-only)."
+          },
+          "isEligibleForFinalDisposition": {
+            "type": "boolean",
+            "description": "True when the entry is currently eligible for final disposition. Computed (read-only)."
+          },
+          "cutoffDate": {
+            "type": "string",
+            "description": "The date the entry was cut off, or null if not cut off. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "cutoffEligibility": {
+            "type": "string",
+            "description": "The date the entry becomes eligible for cutoff, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finalDispositionEligibility": {
+            "type": "string",
+            "description": "The date the entry becomes eligible for final disposition, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "dispositionConfirmationDate": {
+            "type": "string",
+            "description": "The date final disposition was confirmed, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "transferDates": {
+            "type": "array",
+            "description": "Projected and completed interim transfers. Computed (read-only).",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/RecordsManagementTransferDate"
+            }
+          },
+          "locationId": {
+            "type": "integer",
+            "description": "The records management location the entry currently resides at, or null. Computed (read-only).",
+            "format": "int32",
+            "nullable": true
+          },
+          "activeDispositionScheduleId": {
+            "type": "integer",
+            "description": "The disposition schedule currently governing the entry (own or inherited), or null. Computed (read-only).",
+            "format": "int32",
+            "nullable": true
+          },
+          "cutoffCriterionId": {
+            "type": "integer",
+            "description": "The cutoff criterion assigned to the entry, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionScheduleId": {
+            "type": "integer",
+            "description": "The disposition schedule assigned to the entry, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "filingDate": {
+            "type": "string",
+            "description": "The filing date, or null when unset.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "triggerDate": {
+            "type": "string",
+            "description": "The alternate-retention trigger date, or null when unset.",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "discriminator": {
+          "propertyName": "record Type",
+          "mapping": {
+            "Record": "#/components/schemas/RecordProperties",
+            "RecordFolder": "#/components/schemas/RecordFolderProperties"
+          }
+        },
+        "required": [
+          "record Type"
+        ]
       }
     }
   }

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8,7 +8,10 @@
   },
   "servers": [
     {
-      "url": "https://api.laserfiche.com/repository"
+      "url": "http://localhost:11211/repository"
+    },
+    {
+      "url": "https://localhost:11211/repository"
     }
   ],
   "paths": {
@@ -8629,12 +8632,19 @@
             "x-position": 2
           },
           {
-            "name": "for",
-            "x-originalName": "forSelector",
+            "name": "eligibleFor",
             "in": "query",
             "schema": {
-              "type": "string",
-              "nullable": true
+              "oneOf": [
+                {
+                  "nullable": true,
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/EligibleRecordsAction"
+                    }
+                  ]
+                }
+              ]
             },
             "x-position": 3
           },
@@ -15708,11 +15718,12 @@
       },
       "RecordsManagementProperties": {
         "type": "object",
-        "description": "The records management properties of an entry. The same shape describes both a document\nrecord (RecordType = Record) and a record folder\n(RecordType = RecordFolder); members that do not apply to the entry's\ntype are omitted. Many members are computed by the repository and are read-only \u2014 they are\nnoted as such and are ignored on update.",
+        "description": "The records management properties of an entry. This is the abstract base; the concrete shape is\nRecordProperties for a document record (RecordType = Record)\nor RecordFolderProperties for a record folder (RecordFolder). Members\ncommon to both record and record folder live here; type-specific members live on the subtypes.\nMany members are computed by the repository and are read-only \u00e2\u20ac\u201d they are noted as such and are\nignored on update.",
+        "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "recordType": {
-            "description": "Whether these properties describe a document record or a record folder. Determines which\nof the type-specific members are present.",
+            "description": "Whether these properties describe a document record or a record folder. Determines the\nconcrete subtype (RecordProperties or RecordFolderProperties)\nand which type-specific members are present.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/RecordEntryType"
@@ -15807,87 +15818,18 @@
             "description": "The alternate-retention trigger date, or null when unset.",
             "format": "date-time",
             "nullable": true
-          },
-          "recordFolderId": {
-            "type": "integer",
-            "description": "The record folder this record is filed under, or null when independent. Computed (read-only).",
-            "format": "int32",
-            "nullable": true
-          },
-          "underRecordFolder": {
-            "type": "boolean",
-            "description": "True when the record is filed under a record folder. Computed (read-only).",
-            "nullable": true
-          },
-          "isIndividuallyCutoff": {
-            "type": "boolean",
-            "description": "True when the record was cut off individually rather than with its folder. Computed (read-only).",
-            "nullable": true
-          },
-          "isCutoffCriterionInherited": {
-            "type": "boolean",
-            "description": "True when the cutoff criterion is inherited from the record folder.",
-            "nullable": true
-          },
-          "isDispositionScheduleInherited": {
-            "type": "boolean",
-            "description": "True when the disposition schedule is inherited from the record folder.",
-            "nullable": true
-          },
-          "reviewer": {
-            "type": "string",
-            "description": "The reviewer recorded for the last vital-record review, or null. Computed (read-only).",
-            "nullable": true
-          },
-          "lastReviewDate": {
-            "type": "string",
-            "description": "The last vital-record review date, or null when unset.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "nextReviewDate": {
-            "type": "string",
-            "description": "The next scheduled vital-record review date, or null. Computed (read-only).",
-            "format": "date-time",
-            "nullable": true
-          },
-          "isClosed": {
-            "type": "boolean",
-            "description": "True when the record folder is closed to new filings.",
-            "nullable": true
-          },
-          "isPermanent": {
-            "type": "boolean",
-            "description": "True when the record folder is permanent (never destroyed).",
-            "nullable": true
-          },
-          "dispositionAuthority": {
-            "type": "string",
-            "description": "The disposition authority name, or null.",
-            "nullable": true
-          },
-          "reviewCycleId": {
-            "type": "integer",
-            "description": "The vital-record review cycle (calendar cycle) id, or null.",
-            "format": "int32",
-            "nullable": true
-          },
-          "reviewInterval": {
-            "type": "integer",
-            "description": "The vital-record review interval, or null.",
-            "format": "int32",
-            "nullable": true
-          },
-          "reviewIntervalUnit": {
-            "description": "The review interval unit.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/ReviewIntervalUnit"
-              }
-            ]
           }
-        }
+        },
+        "discriminator": {
+          "propertyName": "record Type",
+          "mapping": {
+            "Record": "#/components/schemas/RecordProperties",
+            "RecordFolder": "#/components/schemas/RecordFolderProperties"
+          }
+        },
+        "required": [
+          "record Type"
+        ]
       },
       "RecordEntryType": {
         "type": "string",
@@ -16008,6 +15950,113 @@
           }
         }
       },
+      "RecordProperties": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RecordsManagementProperties"
+          },
+          {
+            "type": "object",
+            "description": "The records management properties of a document record\n(RecordType = Record). Adds the\ndocument-record-only members to the common RecordsManagementProperties shape.",
+            "additionalProperties": false,
+            "properties": {
+              "recordFolderId": {
+                "type": "integer",
+                "description": "The record folder this record is filed under, or null when independent. Computed (read-only).",
+                "format": "int32",
+                "nullable": true
+              },
+              "underRecordFolder": {
+                "type": "boolean",
+                "description": "True when the record is filed under a record folder. Computed (read-only).",
+                "nullable": true
+              },
+              "isIndividuallyCutoff": {
+                "type": "boolean",
+                "description": "True when the record was cut off individually rather than with its folder. Computed (read-only).",
+                "nullable": true
+              },
+              "isCutoffCriterionInherited": {
+                "type": "boolean",
+                "description": "True when the cutoff criterion is inherited from the record folder.",
+                "nullable": true
+              },
+              "isDispositionScheduleInherited": {
+                "type": "boolean",
+                "description": "True when the disposition schedule is inherited from the record folder.",
+                "nullable": true
+              },
+              "reviewer": {
+                "type": "string",
+                "description": "The reviewer recorded for the last vital-record review, or null. Computed (read-only).",
+                "nullable": true
+              },
+              "lastReviewDate": {
+                "type": "string",
+                "description": "The last vital-record review date, or null when unset.",
+                "format": "date-time",
+                "nullable": true
+              },
+              "nextReviewDate": {
+                "type": "string",
+                "description": "The next scheduled vital-record review date, or null. Computed (read-only).",
+                "format": "date-time",
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
+      "RecordFolderProperties": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RecordsManagementProperties"
+          },
+          {
+            "type": "object",
+            "description": "The records management properties of a record folder\n(RecordType = RecordFolder). Adds the\nrecord-folder-only members to the common RecordsManagementProperties shape.",
+            "additionalProperties": false,
+            "properties": {
+              "isClosed": {
+                "type": "boolean",
+                "description": "True when the record folder is closed to new filings.",
+                "nullable": true
+              },
+              "isPermanent": {
+                "type": "boolean",
+                "description": "True when the record folder is permanent (never destroyed).",
+                "nullable": true
+              },
+              "dispositionAuthority": {
+                "type": "string",
+                "description": "The disposition authority name, or null.",
+                "nullable": true
+              },
+              "reviewCycleId": {
+                "type": "integer",
+                "description": "The vital-record review cycle (calendar cycle) id, or null.",
+                "format": "int32",
+                "nullable": true
+              },
+              "reviewInterval": {
+                "type": "integer",
+                "description": "The vital-record review interval, or null.",
+                "format": "int32",
+                "nullable": true
+              },
+              "reviewIntervalUnit": {
+                "description": "The review interval unit.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ReviewIntervalUnit"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
       "ReviewIntervalUnit": {
         "type": "string",
         "description": "The unit of a vital-record review interval. Serialized by name.",
@@ -16057,6 +16106,34 @@
             }
           }
         }
+      },
+      "EligibleRecordsAction": {
+        "type": "string",
+        "description": "The records management action to query a record folder's eligible records for. Used as the\nfor selector on GetEligibleRecords. Serialized by name.",
+        "x-enum-names": [
+          "Disposition",
+          "Transfer"
+        ],
+        "x-enum-varnames": [
+          "Disposition",
+          "Transfer"
+        ],
+        "x-enumNames": [
+          "Disposition",
+          "Transfer"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null
+        ],
+        "enum": [
+          "Disposition",
+          "Transfer"
+        ]
       },
       "AltRetentionEventCollection": {
         "type": "object",

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8383,7 +8383,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/Properties": {
       "get": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "GetEntryRecordsManagementProperties",
         "parameters": [
@@ -8492,7 +8492,7 @@
       },
       "patch": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "UpdateEntryRecordsManagementProperties",
         "parameters": [
@@ -8605,7 +8605,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/EligibleRecords": {
       "get": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "GetEligibleRecords",
         "parameters": [
@@ -8726,7 +8726,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/IndependentRecords": {
       "get": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "GetIndependentRecords",
         "parameters": [
@@ -8837,7 +8837,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/AltRetentionEvents": {
       "get": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "GetAltRetentionEvents",
         "parameters": [
@@ -8948,7 +8948,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordSeries/Properties": {
       "get": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "GetRecordSeriesProperties",
         "parameters": [
@@ -9057,7 +9057,7 @@
       },
       "patch": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "UpdateRecordSeriesProperties",
         "parameters": [
@@ -9170,7 +9170,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/SetEvent": {
       "post": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "SetRecordEvent",
         "parameters": [
@@ -9283,7 +9283,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/RemoveEvent": {
       "post": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "operationId": "RemoveRecordEvent",
         "parameters": [
@@ -9396,7 +9396,7 @@
     "/v2/Repositories/{repositoryId}/Entries/{parentEntryId}/RecordSeries": {
       "post": {
         "tags": [
-          "Entries"
+          "RecordsManagement"
         ],
         "summary": "- A record series provides cascading retention defaults for the file plan beneath it.\n- The parent must be the file-plan root or another record series; creating one under a normal folder is rejected.\n- Deleting a record series uses the existing Delete Entry endpoint (a record series is an entry).\n- Required OAuth scope: repository.Write",
         "operationId": "CreateRecordSeries",

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -3,7 +3,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Laserfiche Repository API",
-    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>1780117020_c895177fae051f04a31fdc4435df804fd4b8cde9</p>",
+    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>0.0.0.1</p>",
     "version": "2"
   },
   "servers": [
@@ -8380,6 +8380,1146 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/Properties": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "GetEntryRecordsManagementProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the entry's records management properties.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordsManagementProperties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record or record folder and therefore has no records management properties.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "UpdateEntryRecordsManagementProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRecordsManagementPropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the entry's records management properties. Returned the updated properties.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordsManagementProperties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record or record folder and therefore has no records management properties.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/EligibleRecords": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "GetEligibleRecords",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "for",
+            "x-originalName": "forSelector",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the ids of the records eligible for the requested action.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordEntryIdCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record folder.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/IndependentRecords": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "GetIndependentRecords",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the ids of the independent records under the record folder.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordEntryIdCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record folder.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/AltRetentionEvents": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "GetAltRetentionEvents",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the record folder's alternate-retention trigger events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AltRetentionEventCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record folder.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordSeries/Properties": {
+      "get": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "GetRecordSeriesProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the record series properties.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordSeriesProperties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record series.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "UpdateRecordSeriesProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRecordSeriesPropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the record series properties. Returned the updated properties.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordSeriesProperties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record series.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/SetEvent": {
+      "post": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "SetRecordEvent",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetRecordEventRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully set the record event date. Returned the updated records management properties.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordsManagementProperties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record or record folder and therefore has no records management properties.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/RemoveEvent": {
+      "post": {
+        "tags": [
+          "Entries"
+        ],
+        "operationId": "RemoveRecordEvent",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemoveRecordEventRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully removed the record event date. Returned the updated records management properties.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordsManagementProperties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The entry was not found, or it is not a record or record folder and therefore has no records management properties.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{parentEntryId}/RecordSeries": {
+      "post": {
+        "tags": [
+          "Entries"
+        ],
+        "summary": "- A record series provides cascading retention defaults for the file plan beneath it.\n- The parent must be the file-plan root or another record series; creating one under a normal folder is rejected.\n- Deleting a record series uses the existing Delete Entry endpoint (a record series is an entry).\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateRecordSeries",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "parentEntryId",
+            "in": "path",
+            "required": true,
+            "description": "The parent the record series is created under. A record series belongs to the record file plan, so the parent must be the repository's file-plan root or an existing record series \u2014 it cannot be a normal folder (the server returns an error if it is).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The new record series' name and code.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRecordSeriesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "201": {
+            "description": "Successfully created the record series. Returned the created entry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Entry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entry with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Entry name conflicts.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories": {
       "get": {
         "tags": [
@@ -11590,6 +12730,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Attribute"
@@ -11695,6 +12836,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/AuditReason"
@@ -12040,6 +13182,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/FieldDefinition"
@@ -12529,6 +13672,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/LinkDefinition"
@@ -13655,6 +14799,7 @@
         "properties": {
           "value": {
             "type": "string",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true
           }
         }
@@ -13772,6 +14917,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Entry"
@@ -13797,6 +14943,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Field"
@@ -13837,6 +14984,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Tag"
@@ -13956,6 +15104,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Link"
@@ -14336,6 +15485,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/PageInfoResponse"
@@ -14521,55 +15671,11 @@
             "nullable": true
           },
           "extent": {
-            "description": "The lock extent. Defaults to All when omitted.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/LockExtent"
-              }
-            ]
+            "type": "string",
+            "description": "The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted.",
+            "nullable": true
           }
         }
-      },
-      "LockExtent": {
-        "type": "string",
-        "description": "The portion of a document that a persistent lock covers.",
-        "x-enum-names": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-varnames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enumNames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-descriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "x-enumDescriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "enum": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ]
       },
       "CheckOutDocumentRequest": {
         "type": "object",
@@ -14600,6 +15706,645 @@
           }
         }
       },
+      "RecordsManagementProperties": {
+        "type": "object",
+        "description": "The records management properties of an entry. The same shape describes both a document\nrecord (RecordType = Record) and a record folder\n(RecordType = RecordFolder); members that do not apply to the entry's\ntype are omitted. Many members are computed by the repository and are read-only \u2014 they are\nnoted as such and are ignored on update.",
+        "additionalProperties": false,
+        "properties": {
+          "recordType": {
+            "description": "Whether these properties describe a document record or a record folder. Determines which\nof the type-specific members are present.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/RecordEntryType"
+              }
+            ]
+          },
+          "dispositionState": {
+            "description": "The current lifecycle state. Computed (read-only).",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DispositionState"
+              }
+            ]
+          },
+          "isCutoff": {
+            "type": "boolean",
+            "description": "True when the entry has been cut off. Computed (read-only)."
+          },
+          "isEligibleForCutoff": {
+            "type": "boolean",
+            "description": "True when the entry is currently eligible for cutoff. Computed (read-only)."
+          },
+          "isEligibleForFinalDisposition": {
+            "type": "boolean",
+            "description": "True when the entry is currently eligible for final disposition. Computed (read-only)."
+          },
+          "cutoffDate": {
+            "type": "string",
+            "description": "The date the entry was cut off, or null if not cut off. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "cutoffEligibility": {
+            "type": "string",
+            "description": "The date the entry becomes eligible for cutoff, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "finalDispositionEligibility": {
+            "type": "string",
+            "description": "The date the entry becomes eligible for final disposition, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "dispositionConfirmationDate": {
+            "type": "string",
+            "description": "The date final disposition was confirmed, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "transferDates": {
+            "type": "array",
+            "description": "Projected and completed interim transfers. Computed (read-only).",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/RecordsManagementTransferDate"
+            }
+          },
+          "locationId": {
+            "type": "integer",
+            "description": "The records management location the entry currently resides at, or null. Computed (read-only).",
+            "format": "int32",
+            "nullable": true
+          },
+          "activeDispositionScheduleId": {
+            "type": "integer",
+            "description": "The disposition schedule currently governing the entry (own or inherited), or null. Computed (read-only).",
+            "format": "int32",
+            "nullable": true
+          },
+          "cutoffCriterionId": {
+            "type": "integer",
+            "description": "The cutoff criterion assigned to the entry, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionScheduleId": {
+            "type": "integer",
+            "description": "The disposition schedule assigned to the entry, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "filingDate": {
+            "type": "string",
+            "description": "The filing date, or null when unset.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "triggerDate": {
+            "type": "string",
+            "description": "The alternate-retention trigger date, or null when unset.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "recordFolderId": {
+            "type": "integer",
+            "description": "The record folder this record is filed under, or null when independent. Computed (read-only).",
+            "format": "int32",
+            "nullable": true
+          },
+          "underRecordFolder": {
+            "type": "boolean",
+            "description": "True when the record is filed under a record folder. Computed (read-only).",
+            "nullable": true
+          },
+          "isIndividuallyCutoff": {
+            "type": "boolean",
+            "description": "True when the record was cut off individually rather than with its folder. Computed (read-only).",
+            "nullable": true
+          },
+          "isCutoffCriterionInherited": {
+            "type": "boolean",
+            "description": "True when the cutoff criterion is inherited from the record folder.",
+            "nullable": true
+          },
+          "isDispositionScheduleInherited": {
+            "type": "boolean",
+            "description": "True when the disposition schedule is inherited from the record folder.",
+            "nullable": true
+          },
+          "reviewer": {
+            "type": "string",
+            "description": "The reviewer recorded for the last vital-record review, or null. Computed (read-only).",
+            "nullable": true
+          },
+          "lastReviewDate": {
+            "type": "string",
+            "description": "The last vital-record review date, or null when unset.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "nextReviewDate": {
+            "type": "string",
+            "description": "The next scheduled vital-record review date, or null. Computed (read-only).",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isClosed": {
+            "type": "boolean",
+            "description": "True when the record folder is closed to new filings.",
+            "nullable": true
+          },
+          "isPermanent": {
+            "type": "boolean",
+            "description": "True when the record folder is permanent (never destroyed).",
+            "nullable": true
+          },
+          "dispositionAuthority": {
+            "type": "string",
+            "description": "The disposition authority name, or null.",
+            "nullable": true
+          },
+          "reviewCycleId": {
+            "type": "integer",
+            "description": "The vital-record review cycle (calendar cycle) id, or null.",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewInterval": {
+            "type": "integer",
+            "description": "The vital-record review interval, or null.",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewIntervalUnit": {
+            "description": "The review interval unit.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReviewIntervalUnit"
+              }
+            ]
+          }
+        }
+      },
+      "RecordEntryType": {
+        "type": "string",
+        "description": "Discriminates which kind of records management entry a set of records management properties\ndescribes. Serialized by name.",
+        "x-enum-names": [
+          "Record",
+          "RecordFolder"
+        ],
+        "x-enum-varnames": [
+          "Record",
+          "RecordFolder"
+        ],
+        "x-enumNames": [
+          "Record",
+          "RecordFolder"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null
+        ],
+        "enum": [
+          "Record",
+          "RecordFolder"
+        ]
+      },
+      "DispositionState": {
+        "type": "string",
+        "description": "The current lifecycle state of a record or record folder. Serialized by name.",
+        "x-enum-names": [
+          "Open",
+          "Closed",
+          "InRetention",
+          "Transferred",
+          "Eligible",
+          "Partial",
+          "Final"
+        ],
+        "x-enum-varnames": [
+          "Open",
+          "Closed",
+          "InRetention",
+          "Transferred",
+          "Eligible",
+          "Partial",
+          "Final"
+        ],
+        "x-enumNames": [
+          "Open",
+          "Closed",
+          "InRetention",
+          "Transferred",
+          "Eligible",
+          "Partial",
+          "Final"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Open",
+          "Closed",
+          "InRetention",
+          "Transferred",
+          "Eligible",
+          "Partial",
+          "Final"
+        ]
+      },
+      "RecordsManagementTransferDate": {
+        "type": "object",
+        "description": "A single interim-transfer step's dates for a record or record folder. A step is either a\ncompleted transfer or a projected one (see Transferred). Output only.",
+        "additionalProperties": false,
+        "properties": {
+          "transferId": {
+            "type": "integer",
+            "description": "The id of the disposition schedule transfer step this date corresponds to.",
+            "format": "int32"
+          },
+          "transferNumber": {
+            "type": "integer",
+            "description": "The ordinal transfer number within the disposition schedule.",
+            "format": "int32"
+          },
+          "date": {
+            "type": "string",
+            "description": "The date the transfer occurred, or null when it has not yet taken place.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "eligibleDate": {
+            "type": "string",
+            "description": "The date the entry becomes (or became) eligible for this transfer.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "transferred": {
+            "type": "boolean",
+            "description": "True when the transfer has taken place; false when this is a projected date."
+          }
+        }
+      },
+      "ReviewIntervalUnit": {
+        "type": "string",
+        "description": "The unit of a vital-record review interval. Serialized by name.",
+        "x-enum-names": [
+          "NotApplicable",
+          "Day",
+          "Month"
+        ],
+        "x-enum-varnames": [
+          "NotApplicable",
+          "Day",
+          "Month"
+        ],
+        "x-enumNames": [
+          "NotApplicable",
+          "Day",
+          "Month"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "NotApplicable",
+          "Day",
+          "Month"
+        ]
+      },
+      "RecordEntryIdCollection": {
+        "type": "object",
+        "description": "A list of entry ids returned by a records management folder query (for example, the records\neligible for disposition or transfer, or the independent records under a record folder).\nCallers join these ids against the entry endpoints to retrieve the entries themselves.",
+        "additionalProperties": false,
+        "properties": {
+          "entryIds": {
+            "type": "array",
+            "description": "The matching entry ids.",
+            "nullable": true,
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "AltRetentionEventCollection": {
+        "type": "object",
+        "description": "The alternate-retention trigger events resolved for a record folder.",
+        "additionalProperties": false,
+        "properties": {
+          "events": {
+            "type": "array",
+            "description": "The alternate-retention trigger events.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/AltRetentionEvent"
+            }
+          }
+        }
+      },
+      "AltRetentionEvent": {
+        "type": "object",
+        "description": "An alternate-retention trigger event resolved for a record folder \u2014 the event whose\noccurrence drives the folder's alternate disposition schedule. Output only.",
+        "additionalProperties": false,
+        "properties": {
+          "entryId": {
+            "type": "integer",
+            "description": "The entry the alternate-retention trigger applies to.",
+            "format": "int32"
+          },
+          "eventId": {
+            "type": "integer",
+            "description": "The records management event definition id that triggers the alternate retention.",
+            "format": "int32"
+          },
+          "triggerDate": {
+            "type": "string",
+            "description": "The date the trigger event is set to occur, or null when unset.",
+            "format": "date-time",
+            "nullable": true
+          }
+        }
+      },
+      "RecordSeriesProperties": {
+        "type": "object",
+        "description": "A record series' retention defaults. A record series provides cascading defaults (cutoff\ncriterion, disposition schedule, review cycle, permanence, disposition authority) that the\nrecord folders and records beneath it resolve against.",
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The record series code.",
+            "nullable": true
+          },
+          "cutoffCriterionId": {
+            "type": "integer",
+            "description": "The default cutoff criterion id, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionScheduleId": {
+            "type": "integer",
+            "description": "The default disposition schedule id, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionAuthority": {
+            "type": "string",
+            "description": "The disposition authority name, or null.",
+            "nullable": true
+          },
+          "isPermanent": {
+            "type": "boolean",
+            "description": "True when records under the series are permanent (never destroyed)."
+          },
+          "reviewCycleId": {
+            "type": "integer",
+            "description": "The default vital-record review cycle (calendar cycle) id, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewInterval": {
+            "type": "integer",
+            "description": "The default vital-record review interval, or null when none.",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewIntervalUnit": {
+            "description": "The default review interval unit.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReviewIntervalUnit"
+              }
+            ]
+          }
+        }
+      },
+      "UpdateRecordsManagementPropertiesRequest": {
+        "type": "object",
+        "description": "Request body for partial-update of an entry's records management properties. Every member is\noptional: null = leave unchanged. Id members accept 0 to clear the assignment.\nDates are set by supplying a value; the two clearable dates (record folder triggerDate\nand record lastReviewDate) are cleared via their explicit clear* flags.\nApplying this update to a plain document promotes it to a record, and to a plain folder\npromotes it to a record folder, before the properties are applied. Members that do not apply\nto the entry's resulting type (for example record-folder members on a document record) are\nrejected with 400.",
+        "additionalProperties": false,
+        "properties": {
+          "cutoffCriterionId": {
+            "type": "integer",
+            "description": "The cutoff criterion id to assign, or 0 to clear.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionScheduleId": {
+            "type": "integer",
+            "description": "The disposition schedule id to assign, or 0 to clear.",
+            "format": "int32",
+            "nullable": true
+          },
+          "filingDate": {
+            "type": "string",
+            "description": "The filing date to set.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "triggerDate": {
+            "type": "string",
+            "description": "The alternate-retention trigger date to set.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isCutoffCriterionInherited": {
+            "type": "boolean",
+            "description": "Whether the cutoff criterion is inherited from the record folder. (record)",
+            "nullable": true
+          },
+          "isDispositionScheduleInherited": {
+            "type": "boolean",
+            "description": "Whether the disposition schedule is inherited from the record folder. (record)",
+            "nullable": true
+          },
+          "lastReviewDate": {
+            "type": "string",
+            "description": "The last vital-record review date to set. (record)",
+            "format": "date-time",
+            "nullable": true
+          },
+          "clearLastReviewDate": {
+            "type": "boolean",
+            "description": "When true, clear the last vital-record review date. (record)"
+          },
+          "clearTriggerDate": {
+            "type": "boolean",
+            "description": "When true, clear the alternate-retention trigger date. (recordFolder)"
+          },
+          "isClosed": {
+            "type": "boolean",
+            "description": "Whether the record folder is closed to new filings. (recordFolder)",
+            "nullable": true
+          },
+          "isPermanent": {
+            "type": "boolean",
+            "description": "Whether the record folder is permanent (never destroyed). (recordFolder)",
+            "nullable": true
+          },
+          "dispositionAuthority": {
+            "type": "string",
+            "description": "The disposition authority name; empty string to clear. (recordFolder)",
+            "nullable": true
+          },
+          "reviewCycleId": {
+            "type": "integer",
+            "description": "The vital-record review cycle (calendar cycle) id to assign, or 0 to clear. (recordFolder)",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewInterval": {
+            "type": "integer",
+            "description": "The vital-record review interval to set. (recordFolder)",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewIntervalUnit": {
+            "description": "The review interval unit. (recordFolder)",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReviewIntervalUnit"
+              }
+            ]
+          }
+        }
+      },
+      "SetRecordEventRequest": {
+        "type": "object",
+        "description": "Request body for setting a records management event date on a record or record folder.",
+        "additionalProperties": false,
+        "properties": {
+          "eventId": {
+            "type": "integer",
+            "description": "The records management event definition id whose date is being set.",
+            "format": "int32"
+          },
+          "date": {
+            "type": "string",
+            "description": "The date to record for the event.",
+            "format": "date-time"
+          }
+        }
+      },
+      "RemoveRecordEventRequest": {
+        "type": "object",
+        "description": "Request body for removing a records management event date from a record or record folder.",
+        "additionalProperties": false,
+        "properties": {
+          "eventId": {
+            "type": "integer",
+            "description": "The records management event definition id whose date is being removed.",
+            "format": "int32"
+          }
+        }
+      },
+      "UpdateRecordSeriesPropertiesRequest": {
+        "type": "object",
+        "description": "Request body for partial-update of a record series' retention defaults. Every member is\noptional: null = leave unchanged. Id members accept 0 to clear the assignment.",
+        "additionalProperties": false,
+        "properties": {
+          "cutoffCriterionId": {
+            "type": "integer",
+            "description": "The default cutoff criterion id to assign, or 0 to clear.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionScheduleId": {
+            "type": "integer",
+            "description": "The default disposition schedule id to assign, or 0 to clear.",
+            "format": "int32",
+            "nullable": true
+          },
+          "dispositionAuthority": {
+            "type": "string",
+            "description": "The disposition authority name; empty string to clear.",
+            "nullable": true
+          },
+          "isPermanent": {
+            "type": "boolean",
+            "description": "Whether records under the series are permanent (never destroyed).",
+            "nullable": true
+          },
+          "reviewCycleId": {
+            "type": "integer",
+            "description": "The default vital-record review cycle (calendar cycle) id to assign, or 0 to clear.",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewInterval": {
+            "type": "integer",
+            "description": "The default vital-record review interval to set.",
+            "format": "int32",
+            "nullable": true
+          },
+          "reviewIntervalUnit": {
+            "description": "The default review interval unit.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReviewIntervalUnit"
+              }
+            ]
+          },
+          "cascade": {
+            "type": "boolean",
+            "description": "When true, cascade the changed defaults to the record folders and records beneath the\nseries. When false (default), only the series' own defaults change."
+          }
+        }
+      },
+      "CreateRecordSeriesRequest": {
+        "type": "object",
+        "description": "Request body for creating a record series under a parent folder.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the new record series.",
+            "nullable": true
+          },
+          "code": {
+            "type": "string",
+            "description": "The record series code.",
+            "nullable": true
+          },
+          "autoRename": {
+            "type": "boolean",
+            "description": "When true, the server appends a suffix to the name on a naming conflict instead of failing."
+          }
+        }
+      },
       "RepositoryCollectionResponse": {
         "type": "object",
         "description": "Response containing a collection of Repository.",
@@ -14607,6 +16352,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Repository"
@@ -14716,6 +16462,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/SearchContextHit"
@@ -14952,6 +16699,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TagDefinition"
@@ -15006,6 +16754,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TaskProgress"
@@ -15189,6 +16938,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/CancelTaskResult"
@@ -15238,6 +16988,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateDefinition"
@@ -15263,6 +17014,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateFieldDefinition"
@@ -15539,11 +17291,11 @@
       },
       "OAuth2 Authorization Code Flow": {
         "type": "oauth2",
-        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>https://api.laserfiche.com/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
+        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>http://localhost:11211/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
         "flows": {
           "authorizationCode": {
-            "authorizationUrl": "https://signin.laserfiche.com/oauth/Authorize",
-            "tokenUrl": "https://signin.laserfiche.com/oauth/Token",
+            "authorizationUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Authorize",
+            "tokenUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Token",
             "scopes": {
               "repository.Read": "Allows the app to read the content of Laserfiche repositories on behalf of the signed-in user.",
               "repository.Write": "Allows the app to modify the content of Laserfiche repositories on behalf of the signed-in user."

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -59,7 +59,7 @@ export class AttributesClient implements IAttributesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -373,7 +373,7 @@ export class AuditReasonsClient implements IAuditReasonsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -654,7 +654,7 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -2026,7 +2026,7 @@ export class LinkDefinitionsClient implements ILinkDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -2920,7 +2920,7 @@ export class EntriesClient implements IEntriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -7969,11 +7969,11 @@ export interface IRecordsManagementClient {
     updateEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordsManagementPropertiesRequest }): Promise<RecordsManagementProperties>;
 
     /**
-     * @param args.forSelector (optional) 
+     * @param args.eligibleFor (optional) 
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the ids of the records eligible for the requested action.
      */
-    getEligibleRecords(args: { repositoryId: string, entryId: number, forSelector?: string | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
+    getEligibleRecords(args: { repositoryId: string, entryId: number, eligibleFor?: EligibleRecordsAction | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
 
     /**
      * @param args.select (optional) Limits the properties returned in the result.
@@ -8028,7 +8028,7 @@ export class RecordsManagementClient implements IRecordsManagementClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -8211,12 +8211,12 @@ export class RecordsManagementClient implements IRecordsManagementClient {
     }
 
     /**
-     * @param args.forSelector (optional) 
+     * @param args.eligibleFor (optional) 
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the ids of the records eligible for the requested action.
      */
-    getEligibleRecords(args: { repositoryId: string, entryId: number, forSelector?: string | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection> {
-        let { repositoryId, entryId, forSelector, select } = args;
+    getEligibleRecords(args: { repositoryId: string, entryId: number, eligibleFor?: EligibleRecordsAction | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection> {
+        let { repositoryId, entryId, eligibleFor, select } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/EligibleRecords?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -8224,8 +8224,8 @@ export class RecordsManagementClient implements IRecordsManagementClient {
         if (entryId === undefined || entryId === null)
             throw new Error("The parameter 'entryId' must be defined.");
         url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
-        if (forSelector !== undefined && forSelector !== null)
-            url_ += "for=" + encodeURIComponent("" + forSelector) + "&";
+        if (eligibleFor !== undefined && eligibleFor !== null)
+            url_ += "eligibleFor=" + encodeURIComponent("" + eligibleFor) + "&";
         if (select !== undefined && select !== null)
             url_ += "$select=" + encodeURIComponent("" + select) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -8961,7 +8961,7 @@ export class RepositoriesClient implements IRepositoriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -9122,7 +9122,7 @@ export class SearchesClient implements ISearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -9696,7 +9696,7 @@ export class SimpleSearchesClient implements ISimpleSearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -9876,7 +9876,7 @@ export class TagDefinitionsClient implements ITagDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -10213,7 +10213,7 @@ export class TasksClient implements ITasksClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     /**
@@ -10694,7 +10694,7 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
     }
 
     
@@ -17641,10 +17641,11 @@ export interface ICheckInDocumentRequest {
     unlock?: boolean;
 }
 
-/** The records management properties of an entry. The same shape describes both a document record (RecordType = Record) and a record folder (RecordType = RecordFolder); members that do not apply to the entry's type are omitted. Many members are computed by the repository and are read-only — they are noted as such and are ignored on update. */
-export class RecordsManagementProperties implements IRecordsManagementProperties {
-    /** Whether these properties describe a document record or a record folder. Determines which
-of the type-specific members are present. */
+/** The records management properties of an entry. This is the abstract base; the concrete shape is RecordProperties for a document record (RecordType = Record) or RecordFolderProperties for a record folder (RecordFolder). Members common to both record and record folder live here; type-specific members live on the subtypes. Many members are computed by the repository and are read-only â€” they are noted as such and are ignored on update. */
+export abstract class RecordsManagementProperties implements IRecordsManagementProperties {
+    /** Whether these properties describe a document record or a record folder. Determines the
+concrete subtype (RecordProperties or RecordFolderProperties)
+and which type-specific members are present. */
     recordType?: RecordEntryType;
     /** The current lifecycle state. Computed (read-only). */
     dispositionState?: DispositionState | undefined;
@@ -17676,34 +17677,7 @@ of the type-specific members are present. */
     filingDate?: Date | undefined;
     /** The alternate-retention trigger date, or null when unset. */
     triggerDate?: Date | undefined;
-    /** The record folder this record is filed under, or null when independent. Computed (read-only). */
-    recordFolderId?: number | undefined;
-    /** True when the record is filed under a record folder. Computed (read-only). */
-    underRecordFolder?: boolean | undefined;
-    /** True when the record was cut off individually rather than with its folder. Computed (read-only). */
-    isIndividuallyCutoff?: boolean | undefined;
-    /** True when the cutoff criterion is inherited from the record folder. */
-    isCutoffCriterionInherited?: boolean | undefined;
-    /** True when the disposition schedule is inherited from the record folder. */
-    isDispositionScheduleInherited?: boolean | undefined;
-    /** The reviewer recorded for the last vital-record review, or null. Computed (read-only). */
-    reviewer?: string | undefined;
-    /** The last vital-record review date, or null when unset. */
-    lastReviewDate?: Date | undefined;
-    /** The next scheduled vital-record review date, or null. Computed (read-only). */
-    nextReviewDate?: Date | undefined;
-    /** True when the record folder is closed to new filings. */
-    isClosed?: boolean | undefined;
-    /** True when the record folder is permanent (never destroyed). */
-    isPermanent?: boolean | undefined;
-    /** The disposition authority name, or null. */
-    dispositionAuthority?: string | undefined;
-    /** The vital-record review cycle (calendar cycle) id, or null. */
-    reviewCycleId?: number | undefined;
-    /** The vital-record review interval, or null. */
-    reviewInterval?: number | undefined;
-    /** The review interval unit. */
-    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+    protected _discriminator: string;
 
     
     
@@ -17714,6 +17688,7 @@ of the type-specific members are present. */
                     (<any>this)[property] = (<any>data)[property];
             }
         }
+        this._discriminator = "RecordsManagementProperties";
     }
 
     init(_data?: any) {
@@ -17738,32 +17713,27 @@ of the type-specific members are present. */
             this.dispositionScheduleId = _data["dispositionScheduleId"];
             this.filingDate = _data["filingDate"] ? new Date(_data["filingDate"].toString()) : <any>undefined;
             this.triggerDate = _data["triggerDate"] ? new Date(_data["triggerDate"].toString()) : <any>undefined;
-            this.recordFolderId = _data["recordFolderId"];
-            this.underRecordFolder = _data["underRecordFolder"];
-            this.isIndividuallyCutoff = _data["isIndividuallyCutoff"];
-            this.isCutoffCriterionInherited = _data["isCutoffCriterionInherited"];
-            this.isDispositionScheduleInherited = _data["isDispositionScheduleInherited"];
-            this.reviewer = _data["reviewer"];
-            this.lastReviewDate = _data["lastReviewDate"] ? new Date(_data["lastReviewDate"].toString()) : <any>undefined;
-            this.nextReviewDate = _data["nextReviewDate"] ? new Date(_data["nextReviewDate"].toString()) : <any>undefined;
-            this.isClosed = _data["isClosed"];
-            this.isPermanent = _data["isPermanent"];
-            this.dispositionAuthority = _data["dispositionAuthority"];
-            this.reviewCycleId = _data["reviewCycleId"];
-            this.reviewInterval = _data["reviewInterval"];
-            this.reviewIntervalUnit = _data["reviewIntervalUnit"];
         }
     }
 
     static fromJS(data: any): RecordsManagementProperties {
         data = typeof data === 'object' ? data : {};
-        let result = new RecordsManagementProperties();
-        result.init(data);
-        return result;
+        if (data["recordType"] === "Record") {
+            let result = new RecordProperties();
+            result.init(data);
+            return result;
+        }
+        if (data["recordType"] === "RecordFolder") {
+            let result = new RecordFolderProperties();
+            result.init(data);
+            return result;
+        }
+        throw new Error("The abstract class 'RecordsManagementProperties' cannot be instantiated.");
     }
 
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
+        data["recordType"] = this._discriminator;
         data["recordType"] = this.recordType;
         data["dispositionState"] = this.dispositionState;
         data["isCutoff"] = this.isCutoff;
@@ -17784,28 +17754,15 @@ of the type-specific members are present. */
         data["dispositionScheduleId"] = this.dispositionScheduleId;
         data["filingDate"] = this.filingDate ? this.filingDate.toISOString() : <any>undefined;
         data["triggerDate"] = this.triggerDate ? this.triggerDate.toISOString() : <any>undefined;
-        data["recordFolderId"] = this.recordFolderId;
-        data["underRecordFolder"] = this.underRecordFolder;
-        data["isIndividuallyCutoff"] = this.isIndividuallyCutoff;
-        data["isCutoffCriterionInherited"] = this.isCutoffCriterionInherited;
-        data["isDispositionScheduleInherited"] = this.isDispositionScheduleInherited;
-        data["reviewer"] = this.reviewer;
-        data["lastReviewDate"] = this.lastReviewDate ? this.lastReviewDate.toISOString() : <any>undefined;
-        data["nextReviewDate"] = this.nextReviewDate ? this.nextReviewDate.toISOString() : <any>undefined;
-        data["isClosed"] = this.isClosed;
-        data["isPermanent"] = this.isPermanent;
-        data["dispositionAuthority"] = this.dispositionAuthority;
-        data["reviewCycleId"] = this.reviewCycleId;
-        data["reviewInterval"] = this.reviewInterval;
-        data["reviewIntervalUnit"] = this.reviewIntervalUnit;
         return data;
     }
 }
 
-/** The records management properties of an entry. The same shape describes both a document record (RecordType = Record) and a record folder (RecordType = RecordFolder); members that do not apply to the entry's type are omitted. Many members are computed by the repository and are read-only — they are noted as such and are ignored on update. */
+/** The records management properties of an entry. This is the abstract base; the concrete shape is RecordProperties for a document record (RecordType = Record) or RecordFolderProperties for a record folder (RecordFolder). Members common to both record and record folder live here; type-specific members live on the subtypes. Many members are computed by the repository and are read-only â€” they are noted as such and are ignored on update. */
 export interface IRecordsManagementProperties {
-    /** Whether these properties describe a document record or a record folder. Determines which
-of the type-specific members are present. */
+    /** Whether these properties describe a document record or a record folder. Determines the
+concrete subtype (RecordProperties or RecordFolderProperties)
+and which type-specific members are present. */
     recordType?: RecordEntryType;
     /** The current lifecycle state. Computed (read-only). */
     dispositionState?: DispositionState | undefined;
@@ -17837,34 +17794,6 @@ of the type-specific members are present. */
     filingDate?: Date | undefined;
     /** The alternate-retention trigger date, or null when unset. */
     triggerDate?: Date | undefined;
-    /** The record folder this record is filed under, or null when independent. Computed (read-only). */
-    recordFolderId?: number | undefined;
-    /** True when the record is filed under a record folder. Computed (read-only). */
-    underRecordFolder?: boolean | undefined;
-    /** True when the record was cut off individually rather than with its folder. Computed (read-only). */
-    isIndividuallyCutoff?: boolean | undefined;
-    /** True when the cutoff criterion is inherited from the record folder. */
-    isCutoffCriterionInherited?: boolean | undefined;
-    /** True when the disposition schedule is inherited from the record folder. */
-    isDispositionScheduleInherited?: boolean | undefined;
-    /** The reviewer recorded for the last vital-record review, or null. Computed (read-only). */
-    reviewer?: string | undefined;
-    /** The last vital-record review date, or null when unset. */
-    lastReviewDate?: Date | undefined;
-    /** The next scheduled vital-record review date, or null. Computed (read-only). */
-    nextReviewDate?: Date | undefined;
-    /** True when the record folder is closed to new filings. */
-    isClosed?: boolean | undefined;
-    /** True when the record folder is permanent (never destroyed). */
-    isPermanent?: boolean | undefined;
-    /** The disposition authority name, or null. */
-    dispositionAuthority?: string | undefined;
-    /** The vital-record review cycle (calendar cycle) id, or null. */
-    reviewCycleId?: number | undefined;
-    /** The vital-record review interval, or null. */
-    reviewInterval?: number | undefined;
-    /** The review interval unit. */
-    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
 }
 
 /** Discriminates which kind of records management entry a set of records management properties describes. Serialized by name. */
@@ -17950,6 +17879,170 @@ export interface IRecordsManagementTransferDate {
     transferred?: boolean;
 }
 
+/** The records management properties of a document record (RecordType = Record). Adds the document-record-only members to the common RecordsManagementProperties shape. */
+export class RecordProperties extends RecordsManagementProperties implements IRecordProperties {
+    /** The record folder this record is filed under, or null when independent. Computed (read-only). */
+    recordFolderId?: number | undefined;
+    /** True when the record is filed under a record folder. Computed (read-only). */
+    underRecordFolder?: boolean | undefined;
+    /** True when the record was cut off individually rather than with its folder. Computed (read-only). */
+    isIndividuallyCutoff?: boolean | undefined;
+    /** True when the cutoff criterion is inherited from the record folder. */
+    isCutoffCriterionInherited?: boolean | undefined;
+    /** True when the disposition schedule is inherited from the record folder. */
+    isDispositionScheduleInherited?: boolean | undefined;
+    /** The reviewer recorded for the last vital-record review, or null. Computed (read-only). */
+    reviewer?: string | undefined;
+    /** The last vital-record review date, or null when unset. */
+    lastReviewDate?: Date | undefined;
+    /** The next scheduled vital-record review date, or null. Computed (read-only). */
+    nextReviewDate?: Date | undefined;
+
+    
+    
+    constructor(data?: IRecordProperties) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Record";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.recordFolderId = _data["recordFolderId"];
+            this.underRecordFolder = _data["underRecordFolder"];
+            this.isIndividuallyCutoff = _data["isIndividuallyCutoff"];
+            this.isCutoffCriterionInherited = _data["isCutoffCriterionInherited"];
+            this.isDispositionScheduleInherited = _data["isDispositionScheduleInherited"];
+            this.reviewer = _data["reviewer"];
+            this.lastReviewDate = _data["lastReviewDate"] ? new Date(_data["lastReviewDate"].toString()) : <any>undefined;
+            this.nextReviewDate = _data["nextReviewDate"] ? new Date(_data["nextReviewDate"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): RecordProperties {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordProperties();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["recordFolderId"] = this.recordFolderId;
+        data["underRecordFolder"] = this.underRecordFolder;
+        data["isIndividuallyCutoff"] = this.isIndividuallyCutoff;
+        data["isCutoffCriterionInherited"] = this.isCutoffCriterionInherited;
+        data["isDispositionScheduleInherited"] = this.isDispositionScheduleInherited;
+        data["reviewer"] = this.reviewer;
+        data["lastReviewDate"] = this.lastReviewDate ? this.lastReviewDate.toISOString() : <any>undefined;
+        data["nextReviewDate"] = this.nextReviewDate ? this.nextReviewDate.toISOString() : <any>undefined;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** The records management properties of a document record (RecordType = Record). Adds the document-record-only members to the common RecordsManagementProperties shape. */
+export interface IRecordProperties extends IRecordsManagementProperties {
+    /** The record folder this record is filed under, or null when independent. Computed (read-only). */
+    recordFolderId?: number | undefined;
+    /** True when the record is filed under a record folder. Computed (read-only). */
+    underRecordFolder?: boolean | undefined;
+    /** True when the record was cut off individually rather than with its folder. Computed (read-only). */
+    isIndividuallyCutoff?: boolean | undefined;
+    /** True when the cutoff criterion is inherited from the record folder. */
+    isCutoffCriterionInherited?: boolean | undefined;
+    /** True when the disposition schedule is inherited from the record folder. */
+    isDispositionScheduleInherited?: boolean | undefined;
+    /** The reviewer recorded for the last vital-record review, or null. Computed (read-only). */
+    reviewer?: string | undefined;
+    /** The last vital-record review date, or null when unset. */
+    lastReviewDate?: Date | undefined;
+    /** The next scheduled vital-record review date, or null. Computed (read-only). */
+    nextReviewDate?: Date | undefined;
+}
+
+/** The records management properties of a record folder (RecordType = RecordFolder). Adds the record-folder-only members to the common RecordsManagementProperties shape. */
+export class RecordFolderProperties extends RecordsManagementProperties implements IRecordFolderProperties {
+    /** True when the record folder is closed to new filings. */
+    isClosed?: boolean | undefined;
+    /** True when the record folder is permanent (never destroyed). */
+    isPermanent?: boolean | undefined;
+    /** The disposition authority name, or null. */
+    dispositionAuthority?: string | undefined;
+    /** The vital-record review cycle (calendar cycle) id, or null. */
+    reviewCycleId?: number | undefined;
+    /** The vital-record review interval, or null. */
+    reviewInterval?: number | undefined;
+    /** The review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+
+    
+    
+    constructor(data?: IRecordFolderProperties) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "RecordFolder";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.isClosed = _data["isClosed"];
+            this.isPermanent = _data["isPermanent"];
+            this.dispositionAuthority = _data["dispositionAuthority"];
+            this.reviewCycleId = _data["reviewCycleId"];
+            this.reviewInterval = _data["reviewInterval"];
+            this.reviewIntervalUnit = _data["reviewIntervalUnit"];
+        }
+    }
+
+    static fromJS(data: any): RecordFolderProperties {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordFolderProperties();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["isClosed"] = this.isClosed;
+        data["isPermanent"] = this.isPermanent;
+        data["dispositionAuthority"] = this.dispositionAuthority;
+        data["reviewCycleId"] = this.reviewCycleId;
+        data["reviewInterval"] = this.reviewInterval;
+        data["reviewIntervalUnit"] = this.reviewIntervalUnit;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** The records management properties of a record folder (RecordType = RecordFolder). Adds the record-folder-only members to the common RecordsManagementProperties shape. */
+export interface IRecordFolderProperties extends IRecordsManagementProperties {
+    /** True when the record folder is closed to new filings. */
+    isClosed?: boolean | undefined;
+    /** True when the record folder is permanent (never destroyed). */
+    isPermanent?: boolean | undefined;
+    /** The disposition authority name, or null. */
+    dispositionAuthority?: string | undefined;
+    /** The vital-record review cycle (calendar cycle) id, or null. */
+    reviewCycleId?: number | undefined;
+    /** The vital-record review interval, or null. */
+    reviewInterval?: number | undefined;
+    /** The review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+}
+
 /** The unit of a vital-record review interval. Serialized by name. */
 export enum ReviewIntervalUnit {
     NotApplicable = "NotApplicable",
@@ -18005,6 +18098,12 @@ export class RecordEntryIdCollection implements IRecordEntryIdCollection {
 export interface IRecordEntryIdCollection {
     /** The matching entry ids. */
     entryIds?: number[] | undefined;
+}
+
+/** The records management action to query a record folder's eligible records for. Used as the for selector on GetEligibleRecords. Serialized by name. */
+export enum EligibleRecordsAction {
+    Disposition = "Disposition",
+    Transfer = "Transfer",
 }
 
 /** The alternate-retention trigger events resolved for a record folder. */

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -2911,6 +2911,69 @@ export interface IEntriesClient {
      * @returns Successfully undid the document check-out. Any persistent lock held on the document has been released.
      */
     undoCheckOut(args: { repositoryId: string, entryId: number }): Promise<Entry>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the entry's records management properties.
+     */
+    getEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordsManagementProperties>;
+
+    /**
+     * @returns Successfully updated the entry's records management properties. Returned the updated properties.
+     */
+    updateEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordsManagementPropertiesRequest }): Promise<RecordsManagementProperties>;
+
+    /**
+     * @param args.forSelector (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the ids of the records eligible for the requested action.
+     */
+    getEligibleRecords(args: { repositoryId: string, entryId: number, forSelector?: string | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the ids of the independent records under the record folder.
+     */
+    getIndependentRecords(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the record folder's alternate-retention trigger events.
+     */
+    getAltRetentionEvents(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AltRetentionEventCollection>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the record series properties.
+     */
+    getRecordSeriesProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordSeriesProperties>;
+
+    /**
+     * @returns Successfully updated the record series properties. Returned the updated properties.
+     */
+    updateRecordSeriesProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordSeriesPropertiesRequest }): Promise<RecordSeriesProperties>;
+
+    /**
+     * @returns Successfully set the record event date. Returned the updated records management properties.
+     */
+    setRecordEvent(args: { repositoryId: string, entryId: number, request: SetRecordEventRequest }): Promise<RecordsManagementProperties>;
+
+    /**
+     * @returns Successfully removed the record event date. Returned the updated records management properties.
+     */
+    removeRecordEvent(args: { repositoryId: string, entryId: number, request: RemoveRecordEventRequest }): Promise<RecordsManagementProperties>;
+
+    /**
+     * - A record series provides cascading retention defaults for the file plan beneath it.
+    - The parent must be the file-plan root or another record series; creating one under a normal folder is rejected.
+    - Deleting a record series uses the existing Delete Entry endpoint (a record series is an entry).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.parentEntryId The parent the record series is created under. A record series belongs to the record file plan, so the parent must be the repository's file-plan root or an existing record series — it cannot be a normal folder (the server returns an error if it is).
+     * @param args.request The new record series' name and code.
+     * @returns Successfully created the record series. Returned the created entry.
+     */
+    createRecordSeries(args: { repositoryId: string, parentEntryId: number, request: CreateRecordSeriesRequest }): Promise<Entry>;
 }
 
 export class EntriesClient implements IEntriesClient {
@@ -7953,6 +8016,918 @@ export class EntriesClient implements IEntriesClient {
         }
         return Promise.resolve<Entry>(null as any);
     }
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the entry's records management properties.
+     */
+    getEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordsManagementProperties> {
+        let { repositoryId, entryId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/Properties?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetEntryRecordsManagementProperties(_response);
+        });
+    }
+
+    protected processGetEntryRecordsManagementProperties(response: Response): Promise<RecordsManagementProperties> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordsManagementProperties.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record or record folder and therefore has no records management properties.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordsManagementProperties>(null as any);
+    }
+
+    /**
+     * @returns Successfully updated the entry's records management properties. Returned the updated properties.
+     */
+    updateEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordsManagementPropertiesRequest }): Promise<RecordsManagementProperties> {
+        let { repositoryId, entryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/Properties";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateEntryRecordsManagementProperties(_response);
+        });
+    }
+
+    protected processUpdateEntryRecordsManagementProperties(response: Response): Promise<RecordsManagementProperties> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordsManagementProperties.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record or record folder and therefore has no records management properties.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordsManagementProperties>(null as any);
+    }
+
+    /**
+     * @param args.forSelector (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the ids of the records eligible for the requested action.
+     */
+    getEligibleRecords(args: { repositoryId: string, entryId: number, forSelector?: string | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection> {
+        let { repositoryId, entryId, forSelector, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/EligibleRecords?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (forSelector !== undefined && forSelector !== null)
+            url_ += "for=" + encodeURIComponent("" + forSelector) + "&";
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetEligibleRecords(_response);
+        });
+    }
+
+    protected processGetEligibleRecords(response: Response): Promise<RecordEntryIdCollection> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordEntryIdCollection.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record folder.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordEntryIdCollection>(null as any);
+    }
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the ids of the independent records under the record folder.
+     */
+    getIndependentRecords(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordEntryIdCollection> {
+        let { repositoryId, entryId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/IndependentRecords?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetIndependentRecords(_response);
+        });
+    }
+
+    protected processGetIndependentRecords(response: Response): Promise<RecordEntryIdCollection> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordEntryIdCollection.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record folder.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordEntryIdCollection>(null as any);
+    }
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the record folder's alternate-retention trigger events.
+     */
+    getAltRetentionEvents(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AltRetentionEventCollection> {
+        let { repositoryId, entryId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/AltRetentionEvents?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetAltRetentionEvents(_response);
+        });
+    }
+
+    protected processGetAltRetentionEvents(response: Response): Promise<AltRetentionEventCollection> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AltRetentionEventCollection.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record folder.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AltRetentionEventCollection>(null as any);
+    }
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the record series properties.
+     */
+    getRecordSeriesProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordSeriesProperties> {
+        let { repositoryId, entryId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordSeries/Properties?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetRecordSeriesProperties(_response);
+        });
+    }
+
+    protected processGetRecordSeriesProperties(response: Response): Promise<RecordSeriesProperties> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordSeriesProperties.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record series.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordSeriesProperties>(null as any);
+    }
+
+    /**
+     * @returns Successfully updated the record series properties. Returned the updated properties.
+     */
+    updateRecordSeriesProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordSeriesPropertiesRequest }): Promise<RecordSeriesProperties> {
+        let { repositoryId, entryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordSeries/Properties";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateRecordSeriesProperties(_response);
+        });
+    }
+
+    protected processUpdateRecordSeriesProperties(response: Response): Promise<RecordSeriesProperties> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordSeriesProperties.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record series.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordSeriesProperties>(null as any);
+    }
+
+    /**
+     * @returns Successfully set the record event date. Returned the updated records management properties.
+     */
+    setRecordEvent(args: { repositoryId: string, entryId: number, request: SetRecordEventRequest }): Promise<RecordsManagementProperties> {
+        let { repositoryId, entryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/SetEvent";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processSetRecordEvent(_response);
+        });
+    }
+
+    protected processSetRecordEvent(response: Response): Promise<RecordsManagementProperties> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordsManagementProperties.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record or record folder and therefore has no records management properties.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordsManagementProperties>(null as any);
+    }
+
+    /**
+     * @returns Successfully removed the record event date. Returned the updated records management properties.
+     */
+    removeRecordEvent(args: { repositoryId: string, entryId: number, request: RemoveRecordEventRequest }): Promise<RecordsManagementProperties> {
+        let { repositoryId, entryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/RemoveEvent";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processRemoveRecordEvent(_response);
+        });
+    }
+
+    protected processRemoveRecordEvent(response: Response): Promise<RecordsManagementProperties> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = RecordsManagementProperties.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The entry was not found, or it is not a record or record folder and therefore has no records management properties.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<RecordsManagementProperties>(null as any);
+    }
+
+    /**
+     * - A record series provides cascading retention defaults for the file plan beneath it.
+    - The parent must be the file-plan root or another record series; creating one under a normal folder is rejected.
+    - Deleting a record series uses the existing Delete Entry endpoint (a record series is an entry).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.parentEntryId The parent the record series is created under. A record series belongs to the record file plan, so the parent must be the repository's file-plan root or an existing record series — it cannot be a normal folder (the server returns an error if it is).
+     * @param args.request The new record series' name and code.
+     * @returns Successfully created the record series. Returned the created entry.
+     */
+    createRecordSeries(args: { repositoryId: string, parentEntryId: number, request: CreateRecordSeriesRequest }): Promise<Entry> {
+        let { repositoryId, parentEntryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{parentEntryId}/RecordSeries";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (parentEntryId === undefined || parentEntryId === null)
+            throw new Error("The parameter 'parentEntryId' must be defined.");
+        url_ = url_.replace("{parentEntryId}", encodeURIComponent("" + parentEntryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processCreateRecordSeries(_response);
+        });
+    }
+
+    protected processCreateRecordSeries(response: Response): Promise<Entry> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 201) {
+            return response.text().then((_responseText) => {
+            let result201: any = null;
+            let resultData201 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result201 = Entry.fromJS(resultData201);
+            return result201;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Entry with requested ID was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 409) {
+            return response.text().then((_responseText) => {
+            let result409: any = null;
+            let resultData409 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result409 = ProblemDetails.fromJS(resultData409);
+            return throwException("Entry name conflicts.", status, _responseText, _headers, result409);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Entry>(null as any);
+    }
 }
 
 export interface IRepositoriesClient {
@@ -11346,6 +12321,7 @@ export class AttributeCollectionResponse implements IAttributeCollectionResponse
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Attribute[] | undefined;
 
     
@@ -11397,6 +12373,7 @@ export interface IAttributeCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Attribute[] | undefined;
 }
 
@@ -11564,6 +12541,7 @@ export class AuditReasonCollectionResponse implements IAuditReasonCollectionResp
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: AuditReason[] | undefined;
 
     
@@ -11615,6 +12593,7 @@ export interface IAuditReasonCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: AuditReason[] | undefined;
 }
 
@@ -11879,6 +12858,7 @@ export class FieldDefinitionCollectionResponse implements IFieldDefinitionCollec
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
 
     
@@ -11930,6 +12910,7 @@ export interface IFieldDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
 }
 
@@ -12852,6 +13833,7 @@ export class LinkDefinitionCollectionResponse implements ILinkDefinitionCollecti
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: LinkDefinition[] | undefined;
 
     
@@ -12903,6 +13885,7 @@ export interface ILinkDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: LinkDefinition[] | undefined;
 }
 
@@ -14696,6 +15679,7 @@ Does not affect pages generated from `file` — use `pdfOptions.generateText` fo
 
 /** Response containing a link to download the exported entry. */
 export class ExportEntryResponse implements IExportEntryResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: string | undefined;
 
     
@@ -14731,6 +15715,7 @@ export class ExportEntryResponse implements IExportEntryResponse {
 
 /** Response containing a link to download the exported entry. */
 export interface IExportEntryResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: string | undefined;
 }
 
@@ -14914,6 +15899,7 @@ export class EntryCollectionResponse implements IEntryCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Entry[] | undefined;
 
     
@@ -14965,6 +15951,7 @@ export interface IEntryCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Entry[] | undefined;
 }
 
@@ -14974,6 +15961,7 @@ export class FieldCollectionResponse implements IFieldCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Field[] | undefined;
 
     
@@ -15025,6 +16013,7 @@ export interface IFieldCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Field[] | undefined;
 }
 
@@ -15084,6 +16073,7 @@ export class TagCollectionResponse implements ITagCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Tag[] | undefined;
 
     
@@ -15135,6 +16125,7 @@ export interface ITagCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Tag[] | undefined;
 }
 
@@ -15338,6 +16329,7 @@ export class LinkCollectionResponse implements ILinkCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Link[] | undefined;
 
     
@@ -15389,6 +16381,7 @@ export interface ILinkCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Link[] | undefined;
 }
 
@@ -16098,6 +17091,7 @@ export class PageInfoCollectionResponse implements IPageInfoCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: PageInfoResponse[] | undefined;
 
     
@@ -16149,6 +17143,7 @@ export interface IPageInfoCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: PageInfoResponse[] | undefined;
 }
 
@@ -16492,8 +17487,8 @@ Account renames change this value over time — do not use for stable identity c
 export class LockDocumentRequest implements ILockDocumentRequest {
     /** An optional comment for the persistent lock. */
     comment?: string | undefined;
-    /** The lock extent. Defaults to All when omitted. */
-    extent?: LockExtent | undefined;
+    /** The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted. */
+    extent?: string | undefined;
 
     
     
@@ -16532,16 +17527,8 @@ export class LockDocumentRequest implements ILockDocumentRequest {
 export interface ILockDocumentRequest {
     /** An optional comment for the persistent lock. */
     comment?: string | undefined;
-    /** The lock extent. Defaults to All when omitted. */
-    extent?: LockExtent | undefined;
-}
-
-/** The portion of a document that a persistent lock covers. */
-export enum LockExtent {
-    Page = "Page",
-    Edoc = "Edoc",
-    Metadata = "Metadata",
-    All = "All",
+    /** The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted. */
+    extent?: string | undefined;
 }
 
 /** Request body for checking out a document. */
@@ -16640,8 +17627,919 @@ export interface ICheckInDocumentRequest {
     unlock?: boolean;
 }
 
+/** The records management properties of an entry. The same shape describes both a document record (RecordType = Record) and a record folder (RecordType = RecordFolder); members that do not apply to the entry's type are omitted. Many members are computed by the repository and are read-only — they are noted as such and are ignored on update. */
+export class RecordsManagementProperties implements IRecordsManagementProperties {
+    /** Whether these properties describe a document record or a record folder. Determines which
+of the type-specific members are present. */
+    recordType?: RecordEntryType;
+    /** The current lifecycle state. Computed (read-only). */
+    dispositionState?: DispositionState | undefined;
+    /** True when the entry has been cut off. Computed (read-only). */
+    isCutoff?: boolean;
+    /** True when the entry is currently eligible for cutoff. Computed (read-only). */
+    isEligibleForCutoff?: boolean;
+    /** True when the entry is currently eligible for final disposition. Computed (read-only). */
+    isEligibleForFinalDisposition?: boolean;
+    /** The date the entry was cut off, or null if not cut off. Computed (read-only). */
+    cutoffDate?: Date | undefined;
+    /** The date the entry becomes eligible for cutoff, or null. Computed (read-only). */
+    cutoffEligibility?: Date | undefined;
+    /** The date the entry becomes eligible for final disposition, or null. Computed (read-only). */
+    finalDispositionEligibility?: Date | undefined;
+    /** The date final disposition was confirmed, or null. Computed (read-only). */
+    dispositionConfirmationDate?: Date | undefined;
+    /** Projected and completed interim transfers. Computed (read-only). */
+    transferDates?: RecordsManagementTransferDate[] | undefined;
+    /** The records management location the entry currently resides at, or null. Computed (read-only). */
+    locationId?: number | undefined;
+    /** The disposition schedule currently governing the entry (own or inherited), or null. Computed (read-only). */
+    activeDispositionScheduleId?: number | undefined;
+    /** The cutoff criterion assigned to the entry, or null when none. */
+    cutoffCriterionId?: number | undefined;
+    /** The disposition schedule assigned to the entry, or null when none. */
+    dispositionScheduleId?: number | undefined;
+    /** The filing date, or null when unset. */
+    filingDate?: Date | undefined;
+    /** The alternate-retention trigger date, or null when unset. */
+    triggerDate?: Date | undefined;
+    /** The record folder this record is filed under, or null when independent. Computed (read-only). */
+    recordFolderId?: number | undefined;
+    /** True when the record is filed under a record folder. Computed (read-only). */
+    underRecordFolder?: boolean | undefined;
+    /** True when the record was cut off individually rather than with its folder. Computed (read-only). */
+    isIndividuallyCutoff?: boolean | undefined;
+    /** True when the cutoff criterion is inherited from the record folder. */
+    isCutoffCriterionInherited?: boolean | undefined;
+    /** True when the disposition schedule is inherited from the record folder. */
+    isDispositionScheduleInherited?: boolean | undefined;
+    /** The reviewer recorded for the last vital-record review, or null. Computed (read-only). */
+    reviewer?: string | undefined;
+    /** The last vital-record review date, or null when unset. */
+    lastReviewDate?: Date | undefined;
+    /** The next scheduled vital-record review date, or null. Computed (read-only). */
+    nextReviewDate?: Date | undefined;
+    /** True when the record folder is closed to new filings. */
+    isClosed?: boolean | undefined;
+    /** True when the record folder is permanent (never destroyed). */
+    isPermanent?: boolean | undefined;
+    /** The disposition authority name, or null. */
+    dispositionAuthority?: string | undefined;
+    /** The vital-record review cycle (calendar cycle) id, or null. */
+    reviewCycleId?: number | undefined;
+    /** The vital-record review interval, or null. */
+    reviewInterval?: number | undefined;
+    /** The review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+
+    
+    
+    constructor(data?: IRecordsManagementProperties) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.recordType = _data["recordType"];
+            this.dispositionState = _data["dispositionState"];
+            this.isCutoff = _data["isCutoff"];
+            this.isEligibleForCutoff = _data["isEligibleForCutoff"];
+            this.isEligibleForFinalDisposition = _data["isEligibleForFinalDisposition"];
+            this.cutoffDate = _data["cutoffDate"] ? new Date(_data["cutoffDate"].toString()) : <any>undefined;
+            this.cutoffEligibility = _data["cutoffEligibility"] ? new Date(_data["cutoffEligibility"].toString()) : <any>undefined;
+            this.finalDispositionEligibility = _data["finalDispositionEligibility"] ? new Date(_data["finalDispositionEligibility"].toString()) : <any>undefined;
+            this.dispositionConfirmationDate = _data["dispositionConfirmationDate"] ? new Date(_data["dispositionConfirmationDate"].toString()) : <any>undefined;
+            if (Array.isArray(_data["transferDates"])) {
+                this.transferDates = [] as any;
+                for (let item of _data["transferDates"])
+                    this.transferDates!.push(RecordsManagementTransferDate.fromJS(item));
+            }
+            this.locationId = _data["locationId"];
+            this.activeDispositionScheduleId = _data["activeDispositionScheduleId"];
+            this.cutoffCriterionId = _data["cutoffCriterionId"];
+            this.dispositionScheduleId = _data["dispositionScheduleId"];
+            this.filingDate = _data["filingDate"] ? new Date(_data["filingDate"].toString()) : <any>undefined;
+            this.triggerDate = _data["triggerDate"] ? new Date(_data["triggerDate"].toString()) : <any>undefined;
+            this.recordFolderId = _data["recordFolderId"];
+            this.underRecordFolder = _data["underRecordFolder"];
+            this.isIndividuallyCutoff = _data["isIndividuallyCutoff"];
+            this.isCutoffCriterionInherited = _data["isCutoffCriterionInherited"];
+            this.isDispositionScheduleInherited = _data["isDispositionScheduleInherited"];
+            this.reviewer = _data["reviewer"];
+            this.lastReviewDate = _data["lastReviewDate"] ? new Date(_data["lastReviewDate"].toString()) : <any>undefined;
+            this.nextReviewDate = _data["nextReviewDate"] ? new Date(_data["nextReviewDate"].toString()) : <any>undefined;
+            this.isClosed = _data["isClosed"];
+            this.isPermanent = _data["isPermanent"];
+            this.dispositionAuthority = _data["dispositionAuthority"];
+            this.reviewCycleId = _data["reviewCycleId"];
+            this.reviewInterval = _data["reviewInterval"];
+            this.reviewIntervalUnit = _data["reviewIntervalUnit"];
+        }
+    }
+
+    static fromJS(data: any): RecordsManagementProperties {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordsManagementProperties();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["recordType"] = this.recordType;
+        data["dispositionState"] = this.dispositionState;
+        data["isCutoff"] = this.isCutoff;
+        data["isEligibleForCutoff"] = this.isEligibleForCutoff;
+        data["isEligibleForFinalDisposition"] = this.isEligibleForFinalDisposition;
+        data["cutoffDate"] = this.cutoffDate ? this.cutoffDate.toISOString() : <any>undefined;
+        data["cutoffEligibility"] = this.cutoffEligibility ? this.cutoffEligibility.toISOString() : <any>undefined;
+        data["finalDispositionEligibility"] = this.finalDispositionEligibility ? this.finalDispositionEligibility.toISOString() : <any>undefined;
+        data["dispositionConfirmationDate"] = this.dispositionConfirmationDate ? this.dispositionConfirmationDate.toISOString() : <any>undefined;
+        if (Array.isArray(this.transferDates)) {
+            data["transferDates"] = [];
+            for (let item of this.transferDates)
+                data["transferDates"].push(item.toJSON());
+        }
+        data["locationId"] = this.locationId;
+        data["activeDispositionScheduleId"] = this.activeDispositionScheduleId;
+        data["cutoffCriterionId"] = this.cutoffCriterionId;
+        data["dispositionScheduleId"] = this.dispositionScheduleId;
+        data["filingDate"] = this.filingDate ? this.filingDate.toISOString() : <any>undefined;
+        data["triggerDate"] = this.triggerDate ? this.triggerDate.toISOString() : <any>undefined;
+        data["recordFolderId"] = this.recordFolderId;
+        data["underRecordFolder"] = this.underRecordFolder;
+        data["isIndividuallyCutoff"] = this.isIndividuallyCutoff;
+        data["isCutoffCriterionInherited"] = this.isCutoffCriterionInherited;
+        data["isDispositionScheduleInherited"] = this.isDispositionScheduleInherited;
+        data["reviewer"] = this.reviewer;
+        data["lastReviewDate"] = this.lastReviewDate ? this.lastReviewDate.toISOString() : <any>undefined;
+        data["nextReviewDate"] = this.nextReviewDate ? this.nextReviewDate.toISOString() : <any>undefined;
+        data["isClosed"] = this.isClosed;
+        data["isPermanent"] = this.isPermanent;
+        data["dispositionAuthority"] = this.dispositionAuthority;
+        data["reviewCycleId"] = this.reviewCycleId;
+        data["reviewInterval"] = this.reviewInterval;
+        data["reviewIntervalUnit"] = this.reviewIntervalUnit;
+        return data;
+    }
+}
+
+/** The records management properties of an entry. The same shape describes both a document record (RecordType = Record) and a record folder (RecordType = RecordFolder); members that do not apply to the entry's type are omitted. Many members are computed by the repository and are read-only — they are noted as such and are ignored on update. */
+export interface IRecordsManagementProperties {
+    /** Whether these properties describe a document record or a record folder. Determines which
+of the type-specific members are present. */
+    recordType?: RecordEntryType;
+    /** The current lifecycle state. Computed (read-only). */
+    dispositionState?: DispositionState | undefined;
+    /** True when the entry has been cut off. Computed (read-only). */
+    isCutoff?: boolean;
+    /** True when the entry is currently eligible for cutoff. Computed (read-only). */
+    isEligibleForCutoff?: boolean;
+    /** True when the entry is currently eligible for final disposition. Computed (read-only). */
+    isEligibleForFinalDisposition?: boolean;
+    /** The date the entry was cut off, or null if not cut off. Computed (read-only). */
+    cutoffDate?: Date | undefined;
+    /** The date the entry becomes eligible for cutoff, or null. Computed (read-only). */
+    cutoffEligibility?: Date | undefined;
+    /** The date the entry becomes eligible for final disposition, or null. Computed (read-only). */
+    finalDispositionEligibility?: Date | undefined;
+    /** The date final disposition was confirmed, or null. Computed (read-only). */
+    dispositionConfirmationDate?: Date | undefined;
+    /** Projected and completed interim transfers. Computed (read-only). */
+    transferDates?: RecordsManagementTransferDate[] | undefined;
+    /** The records management location the entry currently resides at, or null. Computed (read-only). */
+    locationId?: number | undefined;
+    /** The disposition schedule currently governing the entry (own or inherited), or null. Computed (read-only). */
+    activeDispositionScheduleId?: number | undefined;
+    /** The cutoff criterion assigned to the entry, or null when none. */
+    cutoffCriterionId?: number | undefined;
+    /** The disposition schedule assigned to the entry, or null when none. */
+    dispositionScheduleId?: number | undefined;
+    /** The filing date, or null when unset. */
+    filingDate?: Date | undefined;
+    /** The alternate-retention trigger date, or null when unset. */
+    triggerDate?: Date | undefined;
+    /** The record folder this record is filed under, or null when independent. Computed (read-only). */
+    recordFolderId?: number | undefined;
+    /** True when the record is filed under a record folder. Computed (read-only). */
+    underRecordFolder?: boolean | undefined;
+    /** True when the record was cut off individually rather than with its folder. Computed (read-only). */
+    isIndividuallyCutoff?: boolean | undefined;
+    /** True when the cutoff criterion is inherited from the record folder. */
+    isCutoffCriterionInherited?: boolean | undefined;
+    /** True when the disposition schedule is inherited from the record folder. */
+    isDispositionScheduleInherited?: boolean | undefined;
+    /** The reviewer recorded for the last vital-record review, or null. Computed (read-only). */
+    reviewer?: string | undefined;
+    /** The last vital-record review date, or null when unset. */
+    lastReviewDate?: Date | undefined;
+    /** The next scheduled vital-record review date, or null. Computed (read-only). */
+    nextReviewDate?: Date | undefined;
+    /** True when the record folder is closed to new filings. */
+    isClosed?: boolean | undefined;
+    /** True when the record folder is permanent (never destroyed). */
+    isPermanent?: boolean | undefined;
+    /** The disposition authority name, or null. */
+    dispositionAuthority?: string | undefined;
+    /** The vital-record review cycle (calendar cycle) id, or null. */
+    reviewCycleId?: number | undefined;
+    /** The vital-record review interval, or null. */
+    reviewInterval?: number | undefined;
+    /** The review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+}
+
+/** Discriminates which kind of records management entry a set of records management properties describes. Serialized by name. */
+export enum RecordEntryType {
+    Record = "Record",
+    RecordFolder = "RecordFolder",
+}
+
+/** The current lifecycle state of a record or record folder. Serialized by name. */
+export enum DispositionState {
+    Open = "Open",
+    Closed = "Closed",
+    InRetention = "InRetention",
+    Transferred = "Transferred",
+    Eligible = "Eligible",
+    Partial = "Partial",
+    Final = "Final",
+}
+
+/** A single interim-transfer step's dates for a record or record folder. A step is either a completed transfer or a projected one (see Transferred). Output only. */
+export class RecordsManagementTransferDate implements IRecordsManagementTransferDate {
+    /** The id of the disposition schedule transfer step this date corresponds to. */
+    transferId?: number;
+    /** The ordinal transfer number within the disposition schedule. */
+    transferNumber?: number;
+    /** The date the transfer occurred, or null when it has not yet taken place. */
+    date?: Date | undefined;
+    /** The date the entry becomes (or became) eligible for this transfer. */
+    eligibleDate?: Date | undefined;
+    /** True when the transfer has taken place; false when this is a projected date. */
+    transferred?: boolean;
+
+    
+    
+    constructor(data?: IRecordsManagementTransferDate) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.transferId = _data["transferId"];
+            this.transferNumber = _data["transferNumber"];
+            this.date = _data["date"] ? new Date(_data["date"].toString()) : <any>undefined;
+            this.eligibleDate = _data["eligibleDate"] ? new Date(_data["eligibleDate"].toString()) : <any>undefined;
+            this.transferred = _data["transferred"];
+        }
+    }
+
+    static fromJS(data: any): RecordsManagementTransferDate {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordsManagementTransferDate();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["transferId"] = this.transferId;
+        data["transferNumber"] = this.transferNumber;
+        data["date"] = this.date ? this.date.toISOString() : <any>undefined;
+        data["eligibleDate"] = this.eligibleDate ? this.eligibleDate.toISOString() : <any>undefined;
+        data["transferred"] = this.transferred;
+        return data;
+    }
+}
+
+/** A single interim-transfer step's dates for a record or record folder. A step is either a completed transfer or a projected one (see Transferred). Output only. */
+export interface IRecordsManagementTransferDate {
+    /** The id of the disposition schedule transfer step this date corresponds to. */
+    transferId?: number;
+    /** The ordinal transfer number within the disposition schedule. */
+    transferNumber?: number;
+    /** The date the transfer occurred, or null when it has not yet taken place. */
+    date?: Date | undefined;
+    /** The date the entry becomes (or became) eligible for this transfer. */
+    eligibleDate?: Date | undefined;
+    /** True when the transfer has taken place; false when this is a projected date. */
+    transferred?: boolean;
+}
+
+/** The unit of a vital-record review interval. Serialized by name. */
+export enum ReviewIntervalUnit {
+    NotApplicable = "NotApplicable",
+    Day = "Day",
+    Month = "Month",
+}
+
+/** A list of entry ids returned by a records management folder query (for example, the records eligible for disposition or transfer, or the independent records under a record folder). Callers join these ids against the entry endpoints to retrieve the entries themselves. */
+export class RecordEntryIdCollection implements IRecordEntryIdCollection {
+    /** The matching entry ids. */
+    entryIds?: number[] | undefined;
+
+    
+    
+    constructor(data?: IRecordEntryIdCollection) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["entryIds"])) {
+                this.entryIds = [] as any;
+                for (let item of _data["entryIds"])
+                    this.entryIds!.push(item);
+            }
+        }
+    }
+
+    static fromJS(data: any): RecordEntryIdCollection {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordEntryIdCollection();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.entryIds)) {
+            data["entryIds"] = [];
+            for (let item of this.entryIds)
+                data["entryIds"].push(item);
+        }
+        return data;
+    }
+}
+
+/** A list of entry ids returned by a records management folder query (for example, the records eligible for disposition or transfer, or the independent records under a record folder). Callers join these ids against the entry endpoints to retrieve the entries themselves. */
+export interface IRecordEntryIdCollection {
+    /** The matching entry ids. */
+    entryIds?: number[] | undefined;
+}
+
+/** The alternate-retention trigger events resolved for a record folder. */
+export class AltRetentionEventCollection implements IAltRetentionEventCollection {
+    /** The alternate-retention trigger events. */
+    events?: AltRetentionEvent[] | undefined;
+
+    
+    
+    constructor(data?: IAltRetentionEventCollection) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            if (Array.isArray(_data["events"])) {
+                this.events = [] as any;
+                for (let item of _data["events"])
+                    this.events!.push(AltRetentionEvent.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): AltRetentionEventCollection {
+        data = typeof data === 'object' ? data : {};
+        let result = new AltRetentionEventCollection();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.events)) {
+            data["events"] = [];
+            for (let item of this.events)
+                data["events"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+/** The alternate-retention trigger events resolved for a record folder. */
+export interface IAltRetentionEventCollection {
+    /** The alternate-retention trigger events. */
+    events?: AltRetentionEvent[] | undefined;
+}
+
+/** An alternate-retention trigger event resolved for a record folder — the event whose occurrence drives the folder's alternate disposition schedule. Output only. */
+export class AltRetentionEvent implements IAltRetentionEvent {
+    /** The entry the alternate-retention trigger applies to. */
+    entryId?: number;
+    /** The records management event definition id that triggers the alternate retention. */
+    eventId?: number;
+    /** The date the trigger event is set to occur, or null when unset. */
+    triggerDate?: Date | undefined;
+
+    
+    
+    constructor(data?: IAltRetentionEvent) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.entryId = _data["entryId"];
+            this.eventId = _data["eventId"];
+            this.triggerDate = _data["triggerDate"] ? new Date(_data["triggerDate"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): AltRetentionEvent {
+        data = typeof data === 'object' ? data : {};
+        let result = new AltRetentionEvent();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["entryId"] = this.entryId;
+        data["eventId"] = this.eventId;
+        data["triggerDate"] = this.triggerDate ? this.triggerDate.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+/** An alternate-retention trigger event resolved for a record folder — the event whose occurrence drives the folder's alternate disposition schedule. Output only. */
+export interface IAltRetentionEvent {
+    /** The entry the alternate-retention trigger applies to. */
+    entryId?: number;
+    /** The records management event definition id that triggers the alternate retention. */
+    eventId?: number;
+    /** The date the trigger event is set to occur, or null when unset. */
+    triggerDate?: Date | undefined;
+}
+
+/** A record series' retention defaults. A record series provides cascading defaults (cutoff criterion, disposition schedule, review cycle, permanence, disposition authority) that the record folders and records beneath it resolve against. */
+export class RecordSeriesProperties implements IRecordSeriesProperties {
+    /** The record series code. */
+    code?: string | undefined;
+    /** The default cutoff criterion id, or null when none. */
+    cutoffCriterionId?: number | undefined;
+    /** The default disposition schedule id, or null when none. */
+    dispositionScheduleId?: number | undefined;
+    /** The disposition authority name, or null. */
+    dispositionAuthority?: string | undefined;
+    /** True when records under the series are permanent (never destroyed). */
+    isPermanent?: boolean;
+    /** The default vital-record review cycle (calendar cycle) id, or null when none. */
+    reviewCycleId?: number | undefined;
+    /** The default vital-record review interval, or null when none. */
+    reviewInterval?: number | undefined;
+    /** The default review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+
+    
+    
+    constructor(data?: IRecordSeriesProperties) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.code = _data["code"];
+            this.cutoffCriterionId = _data["cutoffCriterionId"];
+            this.dispositionScheduleId = _data["dispositionScheduleId"];
+            this.dispositionAuthority = _data["dispositionAuthority"];
+            this.isPermanent = _data["isPermanent"];
+            this.reviewCycleId = _data["reviewCycleId"];
+            this.reviewInterval = _data["reviewInterval"];
+            this.reviewIntervalUnit = _data["reviewIntervalUnit"];
+        }
+    }
+
+    static fromJS(data: any): RecordSeriesProperties {
+        data = typeof data === 'object' ? data : {};
+        let result = new RecordSeriesProperties();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["code"] = this.code;
+        data["cutoffCriterionId"] = this.cutoffCriterionId;
+        data["dispositionScheduleId"] = this.dispositionScheduleId;
+        data["dispositionAuthority"] = this.dispositionAuthority;
+        data["isPermanent"] = this.isPermanent;
+        data["reviewCycleId"] = this.reviewCycleId;
+        data["reviewInterval"] = this.reviewInterval;
+        data["reviewIntervalUnit"] = this.reviewIntervalUnit;
+        return data;
+    }
+}
+
+/** A record series' retention defaults. A record series provides cascading defaults (cutoff criterion, disposition schedule, review cycle, permanence, disposition authority) that the record folders and records beneath it resolve against. */
+export interface IRecordSeriesProperties {
+    /** The record series code. */
+    code?: string | undefined;
+    /** The default cutoff criterion id, or null when none. */
+    cutoffCriterionId?: number | undefined;
+    /** The default disposition schedule id, or null when none. */
+    dispositionScheduleId?: number | undefined;
+    /** The disposition authority name, or null. */
+    dispositionAuthority?: string | undefined;
+    /** True when records under the series are permanent (never destroyed). */
+    isPermanent?: boolean;
+    /** The default vital-record review cycle (calendar cycle) id, or null when none. */
+    reviewCycleId?: number | undefined;
+    /** The default vital-record review interval, or null when none. */
+    reviewInterval?: number | undefined;
+    /** The default review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+}
+
+/** Request body for partial-update of an entry's records management properties. Every member is optional: null = leave unchanged. Id members accept 0 to clear the assignment. Dates are set by supplying a value; the two clearable dates (record folder triggerDate and record lastReviewDate) are cleared via their explicit clear* flags. Applying this update to a plain document promotes it to a record, and to a plain folder promotes it to a record folder, before the properties are applied. Members that do not apply to the entry's resulting type (for example record-folder members on a document record) are rejected with 400. */
+export class UpdateRecordsManagementPropertiesRequest implements IUpdateRecordsManagementPropertiesRequest {
+    /** The cutoff criterion id to assign, or 0 to clear. */
+    cutoffCriterionId?: number | undefined;
+    /** The disposition schedule id to assign, or 0 to clear. */
+    dispositionScheduleId?: number | undefined;
+    /** The filing date to set. */
+    filingDate?: Date | undefined;
+    /** The alternate-retention trigger date to set. */
+    triggerDate?: Date | undefined;
+    /** Whether the cutoff criterion is inherited from the record folder. (record) */
+    isCutoffCriterionInherited?: boolean | undefined;
+    /** Whether the disposition schedule is inherited from the record folder. (record) */
+    isDispositionScheduleInherited?: boolean | undefined;
+    /** The last vital-record review date to set. (record) */
+    lastReviewDate?: Date | undefined;
+    /** When true, clear the last vital-record review date. (record) */
+    clearLastReviewDate?: boolean;
+    /** When true, clear the alternate-retention trigger date. (recordFolder) */
+    clearTriggerDate?: boolean;
+    /** Whether the record folder is closed to new filings. (recordFolder) */
+    isClosed?: boolean | undefined;
+    /** Whether the record folder is permanent (never destroyed). (recordFolder) */
+    isPermanent?: boolean | undefined;
+    /** The disposition authority name; empty string to clear. (recordFolder) */
+    dispositionAuthority?: string | undefined;
+    /** The vital-record review cycle (calendar cycle) id to assign, or 0 to clear. (recordFolder) */
+    reviewCycleId?: number | undefined;
+    /** The vital-record review interval to set. (recordFolder) */
+    reviewInterval?: number | undefined;
+    /** The review interval unit. (recordFolder) */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+
+    
+    
+    constructor(data?: IUpdateRecordsManagementPropertiesRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.cutoffCriterionId = _data["cutoffCriterionId"];
+            this.dispositionScheduleId = _data["dispositionScheduleId"];
+            this.filingDate = _data["filingDate"] ? new Date(_data["filingDate"].toString()) : <any>undefined;
+            this.triggerDate = _data["triggerDate"] ? new Date(_data["triggerDate"].toString()) : <any>undefined;
+            this.isCutoffCriterionInherited = _data["isCutoffCriterionInherited"];
+            this.isDispositionScheduleInherited = _data["isDispositionScheduleInherited"];
+            this.lastReviewDate = _data["lastReviewDate"] ? new Date(_data["lastReviewDate"].toString()) : <any>undefined;
+            this.clearLastReviewDate = _data["clearLastReviewDate"];
+            this.clearTriggerDate = _data["clearTriggerDate"];
+            this.isClosed = _data["isClosed"];
+            this.isPermanent = _data["isPermanent"];
+            this.dispositionAuthority = _data["dispositionAuthority"];
+            this.reviewCycleId = _data["reviewCycleId"];
+            this.reviewInterval = _data["reviewInterval"];
+            this.reviewIntervalUnit = _data["reviewIntervalUnit"];
+        }
+    }
+
+    static fromJS(data: any): UpdateRecordsManagementPropertiesRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateRecordsManagementPropertiesRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["cutoffCriterionId"] = this.cutoffCriterionId;
+        data["dispositionScheduleId"] = this.dispositionScheduleId;
+        data["filingDate"] = this.filingDate ? this.filingDate.toISOString() : <any>undefined;
+        data["triggerDate"] = this.triggerDate ? this.triggerDate.toISOString() : <any>undefined;
+        data["isCutoffCriterionInherited"] = this.isCutoffCriterionInherited;
+        data["isDispositionScheduleInherited"] = this.isDispositionScheduleInherited;
+        data["lastReviewDate"] = this.lastReviewDate ? this.lastReviewDate.toISOString() : <any>undefined;
+        data["clearLastReviewDate"] = this.clearLastReviewDate;
+        data["clearTriggerDate"] = this.clearTriggerDate;
+        data["isClosed"] = this.isClosed;
+        data["isPermanent"] = this.isPermanent;
+        data["dispositionAuthority"] = this.dispositionAuthority;
+        data["reviewCycleId"] = this.reviewCycleId;
+        data["reviewInterval"] = this.reviewInterval;
+        data["reviewIntervalUnit"] = this.reviewIntervalUnit;
+        return data;
+    }
+}
+
+/** Request body for partial-update of an entry's records management properties. Every member is optional: null = leave unchanged. Id members accept 0 to clear the assignment. Dates are set by supplying a value; the two clearable dates (record folder triggerDate and record lastReviewDate) are cleared via their explicit clear* flags. Applying this update to a plain document promotes it to a record, and to a plain folder promotes it to a record folder, before the properties are applied. Members that do not apply to the entry's resulting type (for example record-folder members on a document record) are rejected with 400. */
+export interface IUpdateRecordsManagementPropertiesRequest {
+    /** The cutoff criterion id to assign, or 0 to clear. */
+    cutoffCriterionId?: number | undefined;
+    /** The disposition schedule id to assign, or 0 to clear. */
+    dispositionScheduleId?: number | undefined;
+    /** The filing date to set. */
+    filingDate?: Date | undefined;
+    /** The alternate-retention trigger date to set. */
+    triggerDate?: Date | undefined;
+    /** Whether the cutoff criterion is inherited from the record folder. (record) */
+    isCutoffCriterionInherited?: boolean | undefined;
+    /** Whether the disposition schedule is inherited from the record folder. (record) */
+    isDispositionScheduleInherited?: boolean | undefined;
+    /** The last vital-record review date to set. (record) */
+    lastReviewDate?: Date | undefined;
+    /** When true, clear the last vital-record review date. (record) */
+    clearLastReviewDate?: boolean;
+    /** When true, clear the alternate-retention trigger date. (recordFolder) */
+    clearTriggerDate?: boolean;
+    /** Whether the record folder is closed to new filings. (recordFolder) */
+    isClosed?: boolean | undefined;
+    /** Whether the record folder is permanent (never destroyed). (recordFolder) */
+    isPermanent?: boolean | undefined;
+    /** The disposition authority name; empty string to clear. (recordFolder) */
+    dispositionAuthority?: string | undefined;
+    /** The vital-record review cycle (calendar cycle) id to assign, or 0 to clear. (recordFolder) */
+    reviewCycleId?: number | undefined;
+    /** The vital-record review interval to set. (recordFolder) */
+    reviewInterval?: number | undefined;
+    /** The review interval unit. (recordFolder) */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+}
+
+/** Request body for setting a records management event date on a record or record folder. */
+export class SetRecordEventRequest implements ISetRecordEventRequest {
+    /** The records management event definition id whose date is being set. */
+    eventId?: number;
+    /** The date to record for the event. */
+    date?: Date;
+
+    
+    
+    constructor(data?: ISetRecordEventRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.eventId = _data["eventId"];
+            this.date = _data["date"] ? new Date(_data["date"].toString()) : <any>undefined;
+        }
+    }
+
+    static fromJS(data: any): SetRecordEventRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new SetRecordEventRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["eventId"] = this.eventId;
+        data["date"] = this.date ? this.date.toISOString() : <any>undefined;
+        return data;
+    }
+}
+
+/** Request body for setting a records management event date on a record or record folder. */
+export interface ISetRecordEventRequest {
+    /** The records management event definition id whose date is being set. */
+    eventId?: number;
+    /** The date to record for the event. */
+    date?: Date;
+}
+
+/** Request body for removing a records management event date from a record or record folder. */
+export class RemoveRecordEventRequest implements IRemoveRecordEventRequest {
+    /** The records management event definition id whose date is being removed. */
+    eventId?: number;
+
+    
+    
+    constructor(data?: IRemoveRecordEventRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.eventId = _data["eventId"];
+        }
+    }
+
+    static fromJS(data: any): RemoveRecordEventRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new RemoveRecordEventRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["eventId"] = this.eventId;
+        return data;
+    }
+}
+
+/** Request body for removing a records management event date from a record or record folder. */
+export interface IRemoveRecordEventRequest {
+    /** The records management event definition id whose date is being removed. */
+    eventId?: number;
+}
+
+/** Request body for partial-update of a record series' retention defaults. Every member is optional: null = leave unchanged. Id members accept 0 to clear the assignment. */
+export class UpdateRecordSeriesPropertiesRequest implements IUpdateRecordSeriesPropertiesRequest {
+    /** The default cutoff criterion id to assign, or 0 to clear. */
+    cutoffCriterionId?: number | undefined;
+    /** The default disposition schedule id to assign, or 0 to clear. */
+    dispositionScheduleId?: number | undefined;
+    /** The disposition authority name; empty string to clear. */
+    dispositionAuthority?: string | undefined;
+    /** Whether records under the series are permanent (never destroyed). */
+    isPermanent?: boolean | undefined;
+    /** The default vital-record review cycle (calendar cycle) id to assign, or 0 to clear. */
+    reviewCycleId?: number | undefined;
+    /** The default vital-record review interval to set. */
+    reviewInterval?: number | undefined;
+    /** The default review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+    /** When true, cascade the changed defaults to the record folders and records beneath the
+series. When false (default), only the series' own defaults change. */
+    cascade?: boolean;
+
+    
+    
+    constructor(data?: IUpdateRecordSeriesPropertiesRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.cutoffCriterionId = _data["cutoffCriterionId"];
+            this.dispositionScheduleId = _data["dispositionScheduleId"];
+            this.dispositionAuthority = _data["dispositionAuthority"];
+            this.isPermanent = _data["isPermanent"];
+            this.reviewCycleId = _data["reviewCycleId"];
+            this.reviewInterval = _data["reviewInterval"];
+            this.reviewIntervalUnit = _data["reviewIntervalUnit"];
+            this.cascade = _data["cascade"];
+        }
+    }
+
+    static fromJS(data: any): UpdateRecordSeriesPropertiesRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateRecordSeriesPropertiesRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["cutoffCriterionId"] = this.cutoffCriterionId;
+        data["dispositionScheduleId"] = this.dispositionScheduleId;
+        data["dispositionAuthority"] = this.dispositionAuthority;
+        data["isPermanent"] = this.isPermanent;
+        data["reviewCycleId"] = this.reviewCycleId;
+        data["reviewInterval"] = this.reviewInterval;
+        data["reviewIntervalUnit"] = this.reviewIntervalUnit;
+        data["cascade"] = this.cascade;
+        return data;
+    }
+}
+
+/** Request body for partial-update of a record series' retention defaults. Every member is optional: null = leave unchanged. Id members accept 0 to clear the assignment. */
+export interface IUpdateRecordSeriesPropertiesRequest {
+    /** The default cutoff criterion id to assign, or 0 to clear. */
+    cutoffCriterionId?: number | undefined;
+    /** The default disposition schedule id to assign, or 0 to clear. */
+    dispositionScheduleId?: number | undefined;
+    /** The disposition authority name; empty string to clear. */
+    dispositionAuthority?: string | undefined;
+    /** Whether records under the series are permanent (never destroyed). */
+    isPermanent?: boolean | undefined;
+    /** The default vital-record review cycle (calendar cycle) id to assign, or 0 to clear. */
+    reviewCycleId?: number | undefined;
+    /** The default vital-record review interval to set. */
+    reviewInterval?: number | undefined;
+    /** The default review interval unit. */
+    reviewIntervalUnit?: ReviewIntervalUnit | undefined;
+    /** When true, cascade the changed defaults to the record folders and records beneath the
+series. When false (default), only the series' own defaults change. */
+    cascade?: boolean;
+}
+
+/** Request body for creating a record series under a parent folder. */
+export class CreateRecordSeriesRequest implements ICreateRecordSeriesRequest {
+    /** The name of the new record series. */
+    name?: string | undefined;
+    /** The record series code. */
+    code?: string | undefined;
+    /** When true, the server appends a suffix to the name on a naming conflict instead of failing. */
+    autoRename?: boolean;
+
+    
+    
+    constructor(data?: ICreateRecordSeriesRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.name = _data["name"];
+            this.code = _data["code"];
+            this.autoRename = _data["autoRename"];
+        }
+    }
+
+    static fromJS(data: any): CreateRecordSeriesRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new CreateRecordSeriesRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["name"] = this.name;
+        data["code"] = this.code;
+        data["autoRename"] = this.autoRename;
+        return data;
+    }
+}
+
+/** Request body for creating a record series under a parent folder. */
+export interface ICreateRecordSeriesRequest {
+    /** The name of the new record series. */
+    name?: string | undefined;
+    /** The record series code. */
+    code?: string | undefined;
+    /** When true, the server appends a suffix to the name on a naming conflict instead of failing. */
+    autoRename?: boolean;
+}
+
 /** Response containing a collection of Repository. */
 export class RepositoryCollectionResponse implements IRepositoryCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: Repository[] | undefined;
 
     
@@ -16685,6 +18583,7 @@ export class RepositoryCollectionResponse implements IRepositoryCollectionRespon
 
 /** Response containing a collection of Repository. */
 export interface IRepositoryCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: Repository[] | undefined;
 }
 
@@ -16808,6 +18707,7 @@ export class SearchContextHitCollectionResponse implements ISearchContextHitColl
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: SearchContextHit[] | undefined;
 
     
@@ -16859,6 +18759,7 @@ export interface ISearchContextHitCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: SearchContextHit[] | undefined;
 }
 
@@ -17056,6 +18957,7 @@ export class TagDefinitionCollectionResponse implements ITagDefinitionCollection
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TagDefinition[] | undefined;
 
     
@@ -17107,6 +19009,7 @@ export interface ITagDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TagDefinition[] | undefined;
 }
 
@@ -17184,6 +19087,7 @@ export interface ITagDefinition {
 
 /** Response containing a collection of TaskProgress. */
 export class TaskCollectionResponse implements ITaskCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: TaskProgress[] | undefined;
 
     
@@ -17227,6 +19131,7 @@ export class TaskCollectionResponse implements ITaskCollectionResponse {
 
 /** Response containing a collection of TaskProgress. */
 export interface ITaskCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: TaskProgress[] | undefined;
 }
 
@@ -17390,6 +19295,7 @@ export interface ITaskResult {
 
 /** Response containing a collection of CancelTaskResult. */
 export class CancelTasksResponse implements ICancelTasksResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: CancelTaskResult[] | undefined;
 
     
@@ -17433,6 +19339,7 @@ export class CancelTasksResponse implements ICancelTasksResponse {
 
 /** Response containing a collection of CancelTaskResult. */
 export interface ICancelTasksResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: CancelTaskResult[] | undefined;
 }
 
@@ -17496,6 +19403,7 @@ export class TemplateDefinitionCollectionResponse implements ITemplateDefinition
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
 
     
@@ -17547,6 +19455,7 @@ export interface ITemplateDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
 }
 
@@ -17556,6 +19465,7 @@ export class TemplateFieldDefinitionCollectionResponse implements ITemplateField
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateFieldDefinition[] | undefined;
 
     
@@ -17607,6 +19517,7 @@ export interface ITemplateFieldDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateFieldDefinition[] | undefined;
 }
 

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -2911,69 +2911,6 @@ export interface IEntriesClient {
      * @returns Successfully undid the document check-out. Any persistent lock held on the document has been released.
      */
     undoCheckOut(args: { repositoryId: string, entryId: number }): Promise<Entry>;
-
-    /**
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the entry's records management properties.
-     */
-    getEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordsManagementProperties>;
-
-    /**
-     * @returns Successfully updated the entry's records management properties. Returned the updated properties.
-     */
-    updateEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordsManagementPropertiesRequest }): Promise<RecordsManagementProperties>;
-
-    /**
-     * @param args.forSelector (optional) 
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the ids of the records eligible for the requested action.
-     */
-    getEligibleRecords(args: { repositoryId: string, entryId: number, forSelector?: string | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
-
-    /**
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the ids of the independent records under the record folder.
-     */
-    getIndependentRecords(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
-
-    /**
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the record folder's alternate-retention trigger events.
-     */
-    getAltRetentionEvents(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AltRetentionEventCollection>;
-
-    /**
-     * @param args.select (optional) Limits the properties returned in the result.
-     * @returns Successfully returned the record series properties.
-     */
-    getRecordSeriesProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordSeriesProperties>;
-
-    /**
-     * @returns Successfully updated the record series properties. Returned the updated properties.
-     */
-    updateRecordSeriesProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordSeriesPropertiesRequest }): Promise<RecordSeriesProperties>;
-
-    /**
-     * @returns Successfully set the record event date. Returned the updated records management properties.
-     */
-    setRecordEvent(args: { repositoryId: string, entryId: number, request: SetRecordEventRequest }): Promise<RecordsManagementProperties>;
-
-    /**
-     * @returns Successfully removed the record event date. Returned the updated records management properties.
-     */
-    removeRecordEvent(args: { repositoryId: string, entryId: number, request: RemoveRecordEventRequest }): Promise<RecordsManagementProperties>;
-
-    /**
-     * - A record series provides cascading retention defaults for the file plan beneath it.
-    - The parent must be the file-plan root or another record series; creating one under a normal folder is rejected.
-    - Deleting a record series uses the existing Delete Entry endpoint (a record series is an entry).
-    - Required OAuth scope: repository.Write
-     * @param args.repositoryId The requested repository ID.
-     * @param args.parentEntryId The parent the record series is created under. A record series belongs to the record file plan, so the parent must be the repository's file-plan root or an existing record series — it cannot be a normal folder (the server returns an error if it is).
-     * @param args.request The new record series' name and code.
-     * @returns Successfully created the record series. Returned the created entry.
-     */
-    createRecordSeries(args: { repositoryId: string, parentEntryId: number, request: CreateRecordSeriesRequest }): Promise<Entry>;
 }
 
 export class EntriesClient implements IEntriesClient {
@@ -8015,6 +7952,83 @@ export class EntriesClient implements IEntriesClient {
             });
         }
         return Promise.resolve<Entry>(null as any);
+    }
+}
+
+export interface IRecordsManagementClient {
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the entry's records management properties.
+     */
+    getEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordsManagementProperties>;
+
+    /**
+     * @returns Successfully updated the entry's records management properties. Returned the updated properties.
+     */
+    updateEntryRecordsManagementProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordsManagementPropertiesRequest }): Promise<RecordsManagementProperties>;
+
+    /**
+     * @param args.forSelector (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the ids of the records eligible for the requested action.
+     */
+    getEligibleRecords(args: { repositoryId: string, entryId: number, forSelector?: string | null | undefined, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the ids of the independent records under the record folder.
+     */
+    getIndependentRecords(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordEntryIdCollection>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the record folder's alternate-retention trigger events.
+     */
+    getAltRetentionEvents(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<AltRetentionEventCollection>;
+
+    /**
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the record series properties.
+     */
+    getRecordSeriesProperties(args: { repositoryId: string, entryId: number, select?: string | null | undefined }): Promise<RecordSeriesProperties>;
+
+    /**
+     * @returns Successfully updated the record series properties. Returned the updated properties.
+     */
+    updateRecordSeriesProperties(args: { repositoryId: string, entryId: number, request: UpdateRecordSeriesPropertiesRequest }): Promise<RecordSeriesProperties>;
+
+    /**
+     * @returns Successfully set the record event date. Returned the updated records management properties.
+     */
+    setRecordEvent(args: { repositoryId: string, entryId: number, request: SetRecordEventRequest }): Promise<RecordsManagementProperties>;
+
+    /**
+     * @returns Successfully removed the record event date. Returned the updated records management properties.
+     */
+    removeRecordEvent(args: { repositoryId: string, entryId: number, request: RemoveRecordEventRequest }): Promise<RecordsManagementProperties>;
+
+    /**
+     * - A record series provides cascading retention defaults for the file plan beneath it.
+    - The parent must be the file-plan root or another record series; creating one under a normal folder is rejected.
+    - Deleting a record series uses the existing Delete Entry endpoint (a record series is an entry).
+    - Required OAuth scope: repository.Write
+     * @param args.repositoryId The requested repository ID.
+     * @param args.parentEntryId The parent the record series is created under. A record series belongs to the record file plan, so the parent must be the repository's file-plan root or an existing record series — it cannot be a normal folder (the server returns an error if it is).
+     * @param args.request The new record series' name and code.
+     * @returns Successfully created the record series. Returned the created entry.
+     */
+    createRecordSeries(args: { repositoryId: string, parentEntryId: number, request: CreateRecordSeriesRequest }): Promise<Entry>;
+}
+
+export class RecordsManagementClient implements IRecordsManagementClient {
+    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : window as any;
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -20167,6 +20181,7 @@ export interface IRepositoryApiClient {
   tasksClient: ITasksClient;
   templateDefinitionsClient: ITemplateDefinitionsClient;
   linkDefinitionsClient: ILinkDefinitionsClient;
+  recordsManagementClient: IRecordsManagementClient;
   defaultRequestHeaders: Record<string, string>;
 }
 
@@ -20185,6 +20200,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
   public tasksClient: ITasksClient;
   public templateDefinitionsClient: ITemplateDefinitionsClient;
   public linkDefinitionsClient: ILinkDefinitionsClient;
+  public recordsManagementClient: IRecordsManagementClient;
 
   private repoClientHandler: RepositoryApiClientHttpHandler;
 
@@ -20224,6 +20240,7 @@ export class RepositoryApiClient implements IRepositoryApiClient {
     this.tasksClient = new TasksClient(this.baseUrl, http);
     this.templateDefinitionsClient = new TemplateDefinitionsClient(this.baseUrl, http);
     this.linkDefinitionsClient = new LinkDefinitionsClient(this.baseUrl, http);
+    this.recordsManagementClient = new RecordsManagementClient(this.baseUrl, http);
   }
 
   /**

--- a/packages/lf-repository-api-client-v2/test/RecordsManagement/RecordsManagement.test.ts
+++ b/packages/lf-repository-api-client-v2/test/RecordsManagement/RecordsManagement.test.ts
@@ -41,14 +41,14 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
   test('getEntryRecordsManagementProperties on a plain folder returns 404', async () => {
     const entryId = await createFolder();
     await expect(
-      _RepositoryApiClient.entriesClient.getEntryRecordsManagementProperties({ repositoryId, entryId })
+      _RepositoryApiClient.recordsManagementClient.getEntryRecordsManagementProperties({ repositoryId, entryId })
     ).rejects.toMatchObject({ status: 404 });
   });
 
   test('updateEntryRecordsManagementProperties auto-promotes a folder to a record folder and persists', async () => {
     const entryId = await createFolder();
 
-    const updated = await _RepositoryApiClient.entriesClient.updateEntryRecordsManagementProperties({
+    const updated = await _RepositoryApiClient.recordsManagementClient.updateEntryRecordsManagementProperties({
       repositoryId,
       entryId,
       request: new UpdateRecordsManagementPropertiesRequest({ isPermanent: true }),
@@ -57,7 +57,7 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
     expect(updated.isPermanent).toBe(true);
 
     // Persistence verify: a fresh GET must reflect the promotion + applied property.
-    const fetched = await _RepositoryApiClient.entriesClient.getEntryRecordsManagementProperties({
+    const fetched = await _RepositoryApiClient.recordsManagementClient.getEntryRecordsManagementProperties({
       repositoryId,
       entryId,
     });
@@ -67,24 +67,24 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
 
   test('record folder queries return (non-null) collections', async () => {
     const entryId = await createFolder();
-    await _RepositoryApiClient.entriesClient.updateEntryRecordsManagementProperties({
+    await _RepositoryApiClient.recordsManagementClient.updateEntryRecordsManagementProperties({
       repositoryId,
       entryId,
       request: new UpdateRecordsManagementPropertiesRequest({ isPermanent: true }),
     });
 
-    const eligibleForDisposition = await _RepositoryApiClient.entriesClient.getEligibleRecords({
+    const eligibleForDisposition = await _RepositoryApiClient.recordsManagementClient.getEligibleRecords({
       repositoryId,
       entryId,
       forSelector: 'disposition',
     });
-    const eligibleForTransfer = await _RepositoryApiClient.entriesClient.getEligibleRecords({
+    const eligibleForTransfer = await _RepositoryApiClient.recordsManagementClient.getEligibleRecords({
       repositoryId,
       entryId,
       forSelector: 'transfer',
     });
-    const independent = await _RepositoryApiClient.entriesClient.getIndependentRecords({ repositoryId, entryId });
-    const altEvents = await _RepositoryApiClient.entriesClient.getAltRetentionEvents({ repositoryId, entryId });
+    const independent = await _RepositoryApiClient.recordsManagementClient.getIndependentRecords({ repositoryId, entryId });
+    const altEvents = await _RepositoryApiClient.recordsManagementClient.getAltRetentionEvents({ repositoryId, entryId });
 
     expect(eligibleForDisposition.entryIds).toBeDefined();
     expect(eligibleForTransfer.entryIds).toBeDefined();
@@ -95,7 +95,7 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
   test('getEligibleRecords without the for selector returns 400', async () => {
     const entryId = await createFolder();
     await expect(
-      _RepositoryApiClient.entriesClient.getEligibleRecords({ repositoryId, entryId })
+      _RepositoryApiClient.recordsManagementClient.getEligibleRecords({ repositoryId, entryId })
     ).rejects.toMatchObject({ status: 400 });
   });
 
@@ -103,7 +103,7 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
     // A record series belongs to the repository's record file plan — it cannot be a child of a normal
     // folder (LFS enforces this). Create it under the repository root (the file-plan root) and record
     // the created series id for cleanup.
-    const created = await _RepositoryApiClient.entriesClient.createRecordSeries({
+    const created = await _RepositoryApiClient.recordsManagementClient.createRecordSeries({
       repositoryId,
       parentEntryId: 1,
       request: new CreateRecordSeriesRequest({ name: 'JS RM Test Series', code: 'RMS' }),
@@ -112,13 +112,13 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
     expect(created.id).toBeGreaterThan(0);
     createdEntryId = created.id!; // cleanup deletes the series (not the root)
 
-    const seriesProps = await _RepositoryApiClient.entriesClient.getRecordSeriesProperties({
+    const seriesProps = await _RepositoryApiClient.recordsManagementClient.getRecordSeriesProperties({
       repositoryId,
       entryId: created.id!,
     });
     expect(seriesProps).toBeDefined();
 
-    const updatedSeries = await _RepositoryApiClient.entriesClient.updateRecordSeriesProperties({
+    const updatedSeries = await _RepositoryApiClient.recordsManagementClient.updateRecordSeriesProperties({
       repositoryId,
       entryId: created.id!,
       request: new UpdateRecordSeriesPropertiesRequest({ isPermanent: true }),

--- a/packages/lf-repository-api-client-v2/test/RecordsManagement/RecordsManagement.test.ts
+++ b/packages/lf-repository-api-client-v2/test/RecordsManagement/RecordsManagement.test.ts
@@ -1,0 +1,126 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId, _RepositoryApiClient } from '../CreateSession.js';
+import { CreateEntry, deleteEntry } from '../BaseTest.js';
+import {
+  CreateRecordSeriesRequest,
+  RecordEntryType,
+  UpdateRecordSeriesPropertiesRequest,
+  UpdateRecordsManagementPropertiesRequest,
+} from '../../index.js';
+
+// Parallel (JS) coverage for the V2 Records Management endpoints (PRD 6.5.D — REQ-RM-ENTRY-001/002/003,
+// REQ-RM-FOLDER-001, REQ-RM-SERIES-001). The dotnet REST integration suite owns the exhaustive contract;
+// these exercise the JS client end-to-end against a running server. No multipart upload, so they run under
+// both vitest+node and vitest+jsdom.
+//
+// Each test creates its OWN folder (autoRename). PATCH auto-promotes that folder to a record folder, so the
+// auto-promote test re-fetches with an independent GET to prove the promotion persisted. afterEach deletes
+// the folder (best-effort — a promoted record folder / record series may resist deletion).
+describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
+  let createdEntryId: number | undefined;
+
+  afterEach(async () => {
+    if (createdEntryId !== undefined) {
+      const entryId = createdEntryId;
+      createdEntryId = undefined;
+      try {
+        await deleteEntry(_RepositoryApiClient, entryId);
+      } catch {
+        /* leftover is harmless */
+      }
+    }
+  });
+
+  async function createFolder(): Promise<number> {
+    const folder = await CreateEntry(_RepositoryApiClient, 'JS RM Test Folder');
+    createdEntryId = folder.id!;
+    return createdEntryId;
+  }
+
+  test('getEntryRecordsManagementProperties on a plain folder returns 404', async () => {
+    const entryId = await createFolder();
+    await expect(
+      _RepositoryApiClient.entriesClient.getEntryRecordsManagementProperties({ repositoryId, entryId })
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  test('updateEntryRecordsManagementProperties auto-promotes a folder to a record folder and persists', async () => {
+    const entryId = await createFolder();
+
+    const updated = await _RepositoryApiClient.entriesClient.updateEntryRecordsManagementProperties({
+      repositoryId,
+      entryId,
+      request: new UpdateRecordsManagementPropertiesRequest({ isPermanent: true }),
+    });
+    expect(updated.recordType).toBe(RecordEntryType.RecordFolder);
+    expect(updated.isPermanent).toBe(true);
+
+    // Persistence verify: a fresh GET must reflect the promotion + applied property.
+    const fetched = await _RepositoryApiClient.entriesClient.getEntryRecordsManagementProperties({
+      repositoryId,
+      entryId,
+    });
+    expect(fetched.recordType).toBe(RecordEntryType.RecordFolder);
+    expect(fetched.isPermanent).toBe(true);
+  });
+
+  test('record folder queries return (non-null) collections', async () => {
+    const entryId = await createFolder();
+    await _RepositoryApiClient.entriesClient.updateEntryRecordsManagementProperties({
+      repositoryId,
+      entryId,
+      request: new UpdateRecordsManagementPropertiesRequest({ isPermanent: true }),
+    });
+
+    const eligibleForDisposition = await _RepositoryApiClient.entriesClient.getEligibleRecords({
+      repositoryId,
+      entryId,
+      forSelector: 'disposition',
+    });
+    const eligibleForTransfer = await _RepositoryApiClient.entriesClient.getEligibleRecords({
+      repositoryId,
+      entryId,
+      forSelector: 'transfer',
+    });
+    const independent = await _RepositoryApiClient.entriesClient.getIndependentRecords({ repositoryId, entryId });
+    const altEvents = await _RepositoryApiClient.entriesClient.getAltRetentionEvents({ repositoryId, entryId });
+
+    expect(eligibleForDisposition.entryIds).toBeDefined();
+    expect(eligibleForTransfer.entryIds).toBeDefined();
+    expect(independent.entryIds).toBeDefined();
+    expect(altEvents.events).toBeDefined();
+  });
+
+  test('getEligibleRecords without the for selector returns 400', async () => {
+    const entryId = await createFolder();
+    await expect(
+      _RepositoryApiClient.entriesClient.getEligibleRecords({ repositoryId, entryId })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  test('createRecordSeries then read and update its series properties', async () => {
+    const parentEntryId = await createFolder();
+
+    const created = await _RepositoryApiClient.entriesClient.createRecordSeries({
+      repositoryId,
+      parentEntryId,
+      request: new CreateRecordSeriesRequest({ name: 'JS RM Test Series', code: 'RMS' }),
+    });
+    expect(created).toBeDefined();
+    expect(created.id).toBeGreaterThan(0);
+
+    const seriesProps = await _RepositoryApiClient.entriesClient.getRecordSeriesProperties({
+      repositoryId,
+      entryId: created.id!,
+    });
+    expect(seriesProps).toBeDefined();
+
+    const updatedSeries = await _RepositoryApiClient.entriesClient.updateRecordSeriesProperties({
+      repositoryId,
+      entryId: created.id!,
+      request: new UpdateRecordSeriesPropertiesRequest({ isPermanent: true }),
+    });
+    expect(updatedSeries.isPermanent).toBe(true);
+  });
+});

--- a/packages/lf-repository-api-client-v2/test/RecordsManagement/RecordsManagement.test.ts
+++ b/packages/lf-repository-api-client-v2/test/RecordsManagement/RecordsManagement.test.ts
@@ -100,15 +100,17 @@ describe('Records Management (REQ-RM-ENTRY/FOLDER/SERIES)', () => {
   });
 
   test('createRecordSeries then read and update its series properties', async () => {
-    const parentEntryId = await createFolder();
-
+    // A record series belongs to the repository's record file plan — it cannot be a child of a normal
+    // folder (LFS enforces this). Create it under the repository root (the file-plan root) and record
+    // the created series id for cleanup.
     const created = await _RepositoryApiClient.entriesClient.createRecordSeries({
       repositoryId,
-      parentEntryId,
+      parentEntryId: 1,
       request: new CreateRecordSeriesRequest({ name: 'JS RM Test Series', code: 'RMS' }),
     });
     expect(created).toBeDefined();
     expect(created.id).toBeGreaterThan(0);
+    createdEntryId = created.id!; // cleanup deletes the series (not the root)
 
     const seriesProps = await _RepositoryApiClient.entriesClient.getRecordSeriesProperties({
       repositoryId,


### PR DESCRIPTION
Regenerates the V2 JS client for the Phase 3 §6.5.D Records Management surface (server PR #173558, work item #674086) and adds smoke tests. The 10 RM operations carry a new `RecordsManagement` OpenApiTag, so they are exposed on a dedicated `recordsManagementClient` (wired into the `RepositoryApiClient` aggregate in `ClientBase.ts`) rather than `entriesClient`. Annotation/Entry polymorphic discriminator override preserved; prod baseUrl restored.

Regen-only: `generate-client/swagger.json` + `index.ts` + `ClientBase.ts` + RM smoke tests. No version bump and no package publish — the consolidated client is versioned/published in a separate, manually-approved release PR.

RM smoke tests pass locally (5/5 node + 5/5 jsdom) vs a local server. In CI they run against dev-CA; they will be red until 6.5.D deploys there (JS has no [SkipIfEndpointMissing] gate).