### PR TITLE
Regenerate V2 client for Annotations & Stamps surface

### DIFF
--- a/packages/lf-repository-api-client-v2/generate-client/swagger-override.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger-override.json
@@ -1,6 +1,118 @@
 {
   "components": {
     "schemas": {
+      "Annotation": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "annotationType",
+          "mapping": {
+            "Highlight": "#/components/schemas/HighlightAnnotation",
+            "Redaction": "#/components/schemas/RedactionAnnotation",
+            "Strikeout": "#/components/schemas/StrikeoutAnnotation",
+            "Underline": "#/components/schemas/UnderlineAnnotation",
+            "Note": "#/components/schemas/NoteAnnotation",
+            "Attachment": "#/components/schemas/AttachmentAnnotation",
+            "TextBox": "#/components/schemas/TextBoxAnnotation",
+            "Bitmap": "#/components/schemas/BitmapAnnotation",
+            "Line": "#/components/schemas/LineAnnotation",
+            "Rectangle": "#/components/schemas/RectangleAnnotation",
+            "Polyline": "#/components/schemas/PolylineAnnotation",
+            "Callout": "#/components/schemas/CalloutAnnotation",
+            "Stamp": "#/components/schemas/StampAnnotation",
+            "FreeHand": "#/components/schemas/FreeHandAnnotation"
+          }
+        },
+        "required": [
+          "annotationType"
+        ],
+        "x-abstract": true,
+        "additionalProperties": false,
+        "properties": {
+          "itemId": {
+            "type": "integer",
+            "description": "The identifier of the annotation, unique within its page.",
+            "format": "int32"
+          },
+          "entryId": {
+            "type": "integer",
+            "description": "The ID of the document entry the annotation belongs to.",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "description": "The 1-based page number the annotation is on.",
+            "format": "int32"
+          },
+          "annotationType": {
+            "description": "The type of the annotation.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationType"
+              }
+            ]
+          },
+          "creator": {
+            "type": "string",
+            "description": "The security identifier (SID) of the user that created the annotation.",
+            "nullable": true
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The UTC time the annotation was created.",
+            "format": "date-time"
+          },
+          "lastModifiedTime": {
+            "type": "string",
+            "description": "The UTC time the annotation was last modified.",
+            "format": "date-time"
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the annotation is read-only (for example, on an archived version)."
+          },
+          "isProtected": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the annotation is protected so that only its creator can modify it."
+          },
+          "visibility": {
+            "description": "Controls who can see the annotation.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationVisibility"
+              }
+            ]
+          },
+          "comment": {
+            "type": "string",
+            "description": "An optional comment on the annotation.",
+            "nullable": true
+          },
+          "customData": {
+            "type": "string",
+            "description": "Optional application-defined custom data stored with the annotation.",
+            "nullable": true
+          },
+          "zOrder": {
+            "type": "integer",
+            "description": "The z-order of the annotation; higher values draw on top.",
+            "format": "int32"
+          },
+          "reasonId": {
+            "type": "integer",
+            "description": "The ID of the redaction reason associated with the annotation, if any.",
+            "format": "int32",
+            "nullable": true
+          },
+          "accessType": {
+            "description": "How the annotation participates in access control.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationAccessControlType"
+              }
+            ]
+          }
+        }
+      },
       "Entry": {
         "type": "object",
         "discriminator": {

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -3,15 +3,1630 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Laserfiche Repository API",
-    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>1780117020_c895177fae051f04a31fdc4435df804fd4b8cde9</p>",
+    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>0.0.0.1</p>",
     "version": "2"
   },
   "servers": [
     {
       "url": "https://api.laserfiche.com/repository"
+    },
+    {
+      "url": "https://api.laserfiche.com/repository"
     }
   ],
   "paths": {
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/Annotations": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Returns every annotation on every page of the document, as a polymorphic list keyed by annotation type.\n- Requires the \"see annotations\" entry right; redaction content is only revealed to callers with the \"see through redactions\" right.\n- Required OAuth scope: repository.Read",
+        "operationId": "ListDocumentAnnotations",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The document entry ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 6
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the annotations on the document.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Annotation"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Returns the annotations on the requested page, as a polymorphic list keyed by annotation type.\n- Requires the \"see annotations\" entry right; redaction content is only revealed to callers with the \"see through redactions\" right.\n- Required OAuth scope: repository.Read",
+        "operationId": "ListPageAnnotations",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The document entry ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "description": "The 1-based page number.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 6
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 7
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the annotations on the page.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Annotation"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- The request body is a polymorphic annotation discriminated by `annotationType`; supply the writable members for that type.\n- For attachment and bitmap annotations, create the annotation first, then upload its binary content via the dedicated sub-resource.\n- Requires the \"annotate\" entry right.\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateAnnotation",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Annotation"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 4
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the annotation. Returned the created annotation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Returns the annotation, typed by annotation type.\n- Requires the \"see annotations\" entry right; redaction content is only revealed to callers with the \"see through redactions\" right.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetAnnotation",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The document entry ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "description": "The 1-based page number.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "description": "The annotation item ID, unique within the page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the requested annotation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Supply only the members to change; omitted members are left unchanged. The `annotationType` must match the existing annotation.\n- Requires the \"annotate\" entry right.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateAnnotation",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Annotation"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 5
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the annotation. Returned the updated annotation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Annotation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Requires the \"annotate\" entry right.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteAnnotation",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the annotation."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Attachment": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Streams the attached file. Fails with a bad request if the annotation is not an attachment.\n- Requires the \"see annotations\" entry right.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetAnnotationAttachment",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "description": "The document entry ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "description": "The 1-based page number.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "description": "The attachment annotation's item ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the content of the attachment annotation.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Send the file as multipart/form-data under the form field \"file\". The annotation must already exist and be an attachment annotation.\n- Requires the \"annotate\" entry right.\n- Required OAuth scope: repository.Write",
+        "operationId": "UploadAnnotationAttachment",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "description": "The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully uploaded the attachment content."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/AnnotationReasons": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Returns the redaction reasons defined in the repository.\n- Required OAuth scope: repository.Read",
+        "operationId": "ListAnnotationReasons",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the repository's annotation reasons.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AnnotationReason"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Required OAuth scope: repository.Write",
+        "operationId": "CreateAnnotationReason",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationReasonRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the annotation reason. Returned the created reason.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationReason"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Image": {
+      "put": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Send the image as multipart/form-data under the form field \"file\". The annotation must already exist and be a bitmap annotation.\n- Requires the \"annotate\" entry right.\n- Required OAuth scope: repository.Write",
+        "operationId": "UploadAnnotationImage",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "entryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "pageNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "itemId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 4
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "description": "The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully uploaded the bitmap annotation image."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested document, page, or annotation was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/AnnotationReasons/{reasonId}": {
+      "patch": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- Required OAuth scope: repository.Write",
+        "operationId": "UpdateAnnotationReason",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "reasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationReasonRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the annotation reason. Returned the updated reason.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationReason"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Annotations"
+        ],
+        "summary": "- When `force` is false, deleting a reason that is in use fails.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteAnnotationReason",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "reasonId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the annotation reason."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/Attributes": {
       "get": {
         "tags": [
@@ -9175,6 +10790,684 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/Stamps": {
+      "get": {
+        "tags": [
+          "Stamps"
+        ],
+        "summary": "- Use `scope` to select public, personal, or all stamps. The image bytes are not included; fetch them from the stamp's Image sub-resource.\n- Required OAuth scope: repository.Read",
+        "operationId": "ListStamps",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/StampScope"
+                }
+              ]
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 6
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the repository's stamps.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Stamp"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Stamps"
+        ],
+        "summary": "- Send the image as multipart/form-data under the form field \"file\", with \"name\" and \"isPublic\" form fields. The service converts the image to the repository's internal format.\n- Creating a public stamp requires the stamp-management privilege; personal stamps require no special privilege.\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateStamp",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "description": "The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the stamp. Returned the created stamp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stamp"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Stamps/{stampId}": {
+      "get": {
+        "tags": [
+          "Stamps"
+        ],
+        "summary": "- Required OAuth scope: repository.Read",
+        "operationId": "GetStamp",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "stampId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the stamp's metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stamp"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested stamp was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Stamps"
+        ],
+        "summary": "- Managing a public stamp requires the stamp-management privilege.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateStamp",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "stampId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateStampRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the stamp. Returned the updated stamp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stamp"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested stamp was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Stamps"
+        ],
+        "summary": "- Deleting a public stamp requires the stamp-management privilege.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteStamp",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "stampId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the stamp."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested stamp was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/Stamps/{stampId}/Image": {
+      "get": {
+        "tags": [
+          "Stamps"
+        ],
+        "summary": "- Use `scope` to indicate whether the stamp is public or personal. An optional `color` (#RRGGBB) recolors the image.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetStampImage",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "stampId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/StampScope"
+                }
+              ]
+            },
+            "x-position": 3
+          },
+          {
+            "name": "color",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the stamp image as a PNG.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested stamp was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/TagDefinitions": {
       "get": {
         "tags": [
@@ -11572,47 +13865,1319 @@
   },
   "components": {
     "schemas": {
-      "AttributeCollectionResponse": {
+      "Annotation": {
         "type": "object",
-        "description": "Response containing a collection of Attribute.",
+        "discriminator": {
+          "propertyName": "annotationType",
+          "mapping": {
+            "Highlight": "#/components/schemas/HighlightAnnotation",
+            "Redaction": "#/components/schemas/RedactionAnnotation",
+            "Strikeout": "#/components/schemas/StrikeoutAnnotation",
+            "Underline": "#/components/schemas/UnderlineAnnotation",
+            "Note": "#/components/schemas/NoteAnnotation",
+            "Attachment": "#/components/schemas/AttachmentAnnotation",
+            "TextBox": "#/components/schemas/TextBoxAnnotation",
+            "Bitmap": "#/components/schemas/BitmapAnnotation",
+            "Line": "#/components/schemas/LineAnnotation",
+            "Rectangle": "#/components/schemas/RectangleAnnotation",
+            "Polyline": "#/components/schemas/PolylineAnnotation",
+            "Callout": "#/components/schemas/CalloutAnnotation",
+            "Stamp": "#/components/schemas/StampAnnotation",
+            "FreeHand": "#/components/schemas/FreeHandAnnotation"
+          }
+        },
+        "required": [
+          "annotationType"
+        ],
+        "x-abstract": true,
         "additionalProperties": false,
         "properties": {
-          "@odata.nextLink": {
+          "itemId": {
+            "type": "integer",
+            "description": "The identifier of the annotation, unique within its page.",
+            "format": "int32"
+          },
+          "entryId": {
+            "type": "integer",
+            "description": "The ID of the document entry the annotation belongs to.",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "description": "The 1-based page number the annotation is on.",
+            "format": "int32"
+          },
+          "annotationType": {
+            "description": "The type of the annotation.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationType"
+              }
+            ]
+          },
+          "creator": {
             "type": "string",
-            "description": "A URL to retrieve the next page of the requested collection.",
+            "description": "The security identifier (SID) of the user that created the annotation.",
             "nullable": true
           },
-          "@odata.count": {
+          "createdTime": {
+            "type": "string",
+            "description": "The UTC time the annotation was created.",
+            "format": "date-time"
+          },
+          "lastModifiedTime": {
+            "type": "string",
+            "description": "The UTC time the annotation was last modified.",
+            "format": "date-time"
+          },
+          "isReadOnly": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the annotation is read-only (for example, on an archived version)."
+          },
+          "isProtected": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the annotation is protected so that only its creator can modify it."
+          },
+          "visibility": {
+            "description": "Controls who can see the annotation.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationVisibility"
+              }
+            ]
+          },
+          "comment": {
+            "type": "string",
+            "description": "An optional comment on the annotation.",
+            "nullable": true
+          },
+          "customData": {
+            "type": "string",
+            "description": "Optional application-defined custom data stored with the annotation.",
+            "nullable": true
+          },
+          "zOrder": {
             "type": "integer",
-            "description": "The total count of items within a collection.",
+            "description": "The z-order of the annotation; higher values draw on top.",
+            "format": "int32"
+          },
+          "reasonId": {
+            "type": "integer",
+            "description": "The ID of the redaction reason associated with the annotation, if any.",
             "format": "int32",
             "nullable": true
           },
-          "value": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/Attribute"
-            }
+          "accessType": {
+            "description": "How the annotation participates in access control.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationAccessControlType"
+              }
+            ]
           }
         }
       },
-      "Attribute": {
+      "AnnotationType": {
+        "type": "string",
+        "description": "The kind of a document annotation. Used as the discriminator for the polymorphic\nAnnotation response.",
+        "x-enum-names": [
+          "Highlight",
+          "Redaction",
+          "Strikeout",
+          "Underline",
+          "Note",
+          "Attachment",
+          "TextBox",
+          "Bitmap",
+          "Line",
+          "Rectangle",
+          "Polyline",
+          "Callout",
+          "Stamp",
+          "FreeHand"
+        ],
+        "x-enum-varnames": [
+          "Highlight",
+          "Redaction",
+          "Strikeout",
+          "Underline",
+          "Note",
+          "Attachment",
+          "TextBox",
+          "Bitmap",
+          "Line",
+          "Rectangle",
+          "Polyline",
+          "Callout",
+          "Stamp",
+          "FreeHand"
+        ],
+        "x-enumNames": [
+          "Highlight",
+          "Redaction",
+          "Strikeout",
+          "Underline",
+          "Note",
+          "Attachment",
+          "TextBox",
+          "Bitmap",
+          "Line",
+          "Rectangle",
+          "Polyline",
+          "Callout",
+          "Stamp",
+          "FreeHand"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Highlight",
+          "Redaction",
+          "Strikeout",
+          "Underline",
+          "Note",
+          "Attachment",
+          "TextBox",
+          "Bitmap",
+          "Line",
+          "Rectangle",
+          "Polyline",
+          "Callout",
+          "Stamp",
+          "FreeHand"
+        ]
+      },
+      "AnnotationVisibility": {
+        "type": "string",
+        "description": "Controls who can see an annotation.",
+        "x-enum-names": [
+          "CreatorAndOwner",
+          "Standard",
+          "AllUsers"
+        ],
+        "x-enum-varnames": [
+          "CreatorAndOwner",
+          "Standard",
+          "AllUsers"
+        ],
+        "x-enumNames": [
+          "CreatorAndOwner",
+          "Standard",
+          "AllUsers"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "CreatorAndOwner",
+          "Standard",
+          "AllUsers"
+        ]
+      },
+      "AnnotationAccessControlType": {
+        "type": "string",
+        "description": "How an annotation participates in access control.",
+        "x-enum-names": [
+          "None",
+          "Allow",
+          "Deny"
+        ],
+        "x-enum-varnames": [
+          "None",
+          "Allow",
+          "Deny"
+        ],
+        "x-enumNames": [
+          "None",
+          "Allow",
+          "Deny"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "None",
+          "Allow",
+          "Deny"
+        ]
+      },
+      "HighlightAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "Highlights one or more regions of a page.",
+            "additionalProperties": false,
+            "properties": {
+              "color": {
+                "type": "string",
+                "description": "The highlight color as an RGB hex string (for example, \"#FFFF00\"); null if transparent.",
+                "nullable": true
+              },
+              "textStart": {
+                "type": "integer",
+                "description": "The start offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "textEnd": {
+                "type": "integer",
+                "description": "The end offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "rectangles": {
+                "type": "array",
+                "description": "The rectangular regions covered by the highlight.",
+                "nullable": true,
+                "items": {
+                  "$ref": "#/components/schemas/AnnotationRectangle"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "AnnotationRectangle": {
         "type": "object",
-        "description": "Represents a trustee attribute.",
+        "description": "A rectangular region on a page, in image pixels from the top-left corner.",
         "additionalProperties": false,
         "properties": {
-          "key": {
-            "type": "string",
-            "description": "The attribute key.",
-            "nullable": true
+          "x": {
+            "type": "integer",
+            "description": "The horizontal offset in pixels of the left edge of the rectangle.",
+            "format": "int32"
           },
-          "value": {
-            "type": "string",
-            "description": "The attribute value.",
-            "nullable": true
+          "y": {
+            "type": "integer",
+            "description": "The vertical offset in pixels of the top edge of the rectangle.",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "description": "The width of the rectangle in pixels.",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "description": "The height of the rectangle in pixels.",
+            "format": "int32"
           }
         }
+      },
+      "RedactionAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "Obscures one or more regions of a page. Redactions are overlays; the underlying content\nis preserved and is only hidden from users without the right to see through redactions.",
+            "additionalProperties": false,
+            "properties": {
+              "isWhiteout": {
+                "type": "boolean",
+                "description": "A boolean indicating whether the region is whited out (true) rather than blacked out (false)."
+              },
+              "textStart": {
+                "type": "integer",
+                "description": "The start offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "textEnd": {
+                "type": "integer",
+                "description": "The end offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "rectangles": {
+                "type": "array",
+                "description": "The rectangular regions covered by the redaction.",
+                "nullable": true,
+                "items": {
+                  "$ref": "#/components/schemas/AnnotationRectangle"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "StrikeoutAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "Strikes through one or more regions of a page.",
+            "additionalProperties": false,
+            "properties": {
+              "color": {
+                "type": "string",
+                "description": "The strikeout color as an RGB hex string (for example, \"#FF0000\"); null if transparent.",
+                "nullable": true
+              },
+              "direction": {
+                "description": "The reading direction of the struck-through text.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TextDirection"
+                  }
+                ]
+              },
+              "textStart": {
+                "type": "integer",
+                "description": "The start offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "textEnd": {
+                "type": "integer",
+                "description": "The end offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "rectangles": {
+                "type": "array",
+                "description": "The rectangular regions covered by the strikeout.",
+                "nullable": true,
+                "items": {
+                  "$ref": "#/components/schemas/AnnotationRectangle"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "TextDirection": {
+        "type": "string",
+        "description": "The reading direction of annotation text.",
+        "x-enum-names": [
+          "LeftToRight",
+          "TopToBottom",
+          "RightToLeft",
+          "BottomToTop"
+        ],
+        "x-enum-varnames": [
+          "LeftToRight",
+          "TopToBottom",
+          "RightToLeft",
+          "BottomToTop"
+        ],
+        "x-enumNames": [
+          "LeftToRight",
+          "TopToBottom",
+          "RightToLeft",
+          "BottomToTop"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "LeftToRight",
+          "TopToBottom",
+          "RightToLeft",
+          "BottomToTop"
+        ]
+      },
+      "UnderlineAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "Underlines one or more regions of a page.",
+            "additionalProperties": false,
+            "properties": {
+              "color": {
+                "type": "string",
+                "description": "The underline color as an RGB hex string (for example, \"#FF0000\"); null if transparent.",
+                "nullable": true
+              },
+              "direction": {
+                "description": "The reading direction of the underlined text.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TextDirection"
+                  }
+                ]
+              },
+              "textStart": {
+                "type": "integer",
+                "description": "The start offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "textEnd": {
+                "type": "integer",
+                "description": "The end offset of the linked text span, or -1 when not linked to text.",
+                "format": "int32"
+              },
+              "rectangles": {
+                "type": "array",
+                "description": "The rectangular regions covered by the underline.",
+                "nullable": true,
+                "items": {
+                  "$ref": "#/components/schemas/AnnotationRectangle"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "NoteAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A sticky note placed on a page.",
+            "additionalProperties": false,
+            "properties": {
+              "position": {
+                "description": "The top-left position of the note on the page.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "color": {
+                "type": "string",
+                "description": "The background color of the note as an RGB hex string (for example, \"#FFFF00\"); null if transparent.",
+                "nullable": true
+              },
+              "text": {
+                "type": "string",
+                "description": "The text content of the note.",
+                "nullable": true
+              },
+              "keepHistory": {
+                "type": "boolean",
+                "description": "A boolean indicating whether the note keeps a revision history."
+              }
+            }
+          }
+        ]
+      },
+      "AnnotationPoint": {
+        "type": "object",
+        "description": "A point on a page, in image pixels from the top-left corner.",
+        "additionalProperties": false,
+        "properties": {
+          "x": {
+            "type": "integer",
+            "description": "The horizontal offset in pixels from the left edge of the page.",
+            "format": "int32"
+          },
+          "y": {
+            "type": "integer",
+            "description": "The vertical offset in pixels from the top edge of the page.",
+            "format": "int32"
+          }
+        }
+      },
+      "AttachmentAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A file attached to a page. The attached file's bytes are retrieved through the\nattachment-content endpoint, not in the annotation response.",
+            "additionalProperties": false,
+            "properties": {
+              "position": {
+                "description": "The top-left position of the attachment icon on the page.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "fileName": {
+                "type": "string",
+                "description": "The original file name of the attachment.",
+                "nullable": true
+              },
+              "mimeType": {
+                "type": "string",
+                "description": "The MIME type of the attached file.",
+                "nullable": true
+              },
+              "attachmentLength": {
+                "type": "integer",
+                "description": "The size of the attached file in bytes.",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "TextBoxAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A bordered text box drawn on a page.",
+            "additionalProperties": false,
+            "properties": {
+              "coordinates": {
+                "description": "The bounding rectangle of the text box.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationRectangle"
+                  }
+                ]
+              },
+              "fillColor": {
+                "type": "string",
+                "description": "The fill color as an RGB hex string; null if not filled.",
+                "nullable": true
+              },
+              "borderColor": {
+                "type": "string",
+                "description": "The border color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "borderStyle": {
+                "description": "The border stroke style.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineStyle"
+                  }
+                ]
+              },
+              "borderThickness": {
+                "type": "integer",
+                "description": "The border thickness in pixels.",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the text box as a percentage (0-100).",
+                "format": "int32"
+              },
+              "text": {
+                "type": "string",
+                "description": "The text displayed in the box.",
+                "nullable": true
+              },
+              "textSize": {
+                "type": "integer",
+                "description": "The font size of the text in points.",
+                "format": "int32"
+              },
+              "direction": {
+                "description": "The reading direction of the text.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TextDirection"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "LineStyle": {
+        "type": "string",
+        "description": "The stroke style of a line or border.",
+        "x-enum-names": [
+          "Solid",
+          "Dashed1",
+          "Dashed2",
+          "Dashed3",
+          "Dashed4",
+          "Dashed5",
+          "Dashed6",
+          "Cloud1",
+          "Cloud2"
+        ],
+        "x-enum-varnames": [
+          "Solid",
+          "Dashed1",
+          "Dashed2",
+          "Dashed3",
+          "Dashed4",
+          "Dashed5",
+          "Dashed6",
+          "Cloud1",
+          "Cloud2"
+        ],
+        "x-enumNames": [
+          "Solid",
+          "Dashed1",
+          "Dashed2",
+          "Dashed3",
+          "Dashed4",
+          "Dashed5",
+          "Dashed6",
+          "Cloud1",
+          "Cloud2"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Solid",
+          "Dashed1",
+          "Dashed2",
+          "Dashed3",
+          "Dashed4",
+          "Dashed5",
+          "Dashed6",
+          "Cloud1",
+          "Cloud2"
+        ]
+      },
+      "BitmapAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "An image placed on a page. The image bytes are not included in the annotation response;\nthey are uploaded and managed separately.",
+            "additionalProperties": false,
+            "properties": {
+              "position": {
+                "description": "The top-left position of the image on the page.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "size": {
+                "description": "The rendered size of the image in pixels.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationSize"
+                  }
+                ]
+              },
+              "rotation": {
+                "type": "integer",
+                "description": "The clockwise rotation of the image in degrees (0-359).",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the image as a percentage (0-100).",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "AnnotationSize": {
+        "type": "object",
+        "description": "A size in image pixels.",
+        "additionalProperties": false,
+        "properties": {
+          "width": {
+            "type": "integer",
+            "description": "The width in pixels.",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "description": "The height in pixels.",
+            "format": "int32"
+          }
+        }
+      },
+      "LineAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A straight line or arrow drawn on a page.",
+            "additionalProperties": false,
+            "properties": {
+              "beginPosition": {
+                "description": "The start point of the line.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "endPosition": {
+                "description": "The end point of the line.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "beginStyle": {
+                "description": "The cap style at the start of the line.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineEndingStyle"
+                  }
+                ]
+              },
+              "endStyle": {
+                "description": "The cap style at the end of the line.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineEndingStyle"
+                  }
+                ]
+              },
+              "lineStyle": {
+                "description": "The line stroke style.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineStyle"
+                  }
+                ]
+              },
+              "color": {
+                "type": "string",
+                "description": "The line color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "endColor": {
+                "type": "string",
+                "description": "The end-cap color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "thickness": {
+                "type": "integer",
+                "description": "The line thickness in pixels.",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the line as a percentage (0-100).",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "LineEndingStyle": {
+        "type": "string",
+        "description": "The cap style at the end of a line.",
+        "x-enum-names": [
+          "None",
+          "Open",
+          "Closed",
+          "OpenReversed",
+          "ClosedReversed",
+          "Butt",
+          "Diamond",
+          "Round",
+          "Square",
+          "Slash"
+        ],
+        "x-enum-varnames": [
+          "None",
+          "Open",
+          "Closed",
+          "OpenReversed",
+          "ClosedReversed",
+          "Butt",
+          "Diamond",
+          "Round",
+          "Square",
+          "Slash"
+        ],
+        "x-enumNames": [
+          "None",
+          "Open",
+          "Closed",
+          "OpenReversed",
+          "ClosedReversed",
+          "Butt",
+          "Diamond",
+          "Round",
+          "Square",
+          "Slash"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "None",
+          "Open",
+          "Closed",
+          "OpenReversed",
+          "ClosedReversed",
+          "Butt",
+          "Diamond",
+          "Round",
+          "Square",
+          "Slash"
+        ]
+      },
+      "RectangleAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A rectangle, rounded rectangle, or ellipse drawn on a page.",
+            "additionalProperties": false,
+            "properties": {
+              "coordinates": {
+                "description": "The bounding rectangle of the shape.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationRectangle"
+                  }
+                ]
+              },
+              "fillColor": {
+                "type": "string",
+                "description": "The fill color as an RGB hex string (for example, \"#FF0000\"); null if not filled.",
+                "nullable": true
+              },
+              "boxStyle": {
+                "description": "The shape drawn within the bounding rectangle.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BoxStyle"
+                  }
+                ]
+              },
+              "borderStyle": {
+                "description": "The border stroke style.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineStyle"
+                  }
+                ]
+              },
+              "borderColor": {
+                "type": "string",
+                "description": "The border color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "borderThickness": {
+                "type": "integer",
+                "description": "The border thickness in pixels.",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the shape as a percentage (0-100).",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "BoxStyle": {
+        "type": "string",
+        "description": "The shape of a rectangle annotation.",
+        "x-enum-names": [
+          "Rectangle",
+          "Ellipse",
+          "RoundedRectangle"
+        ],
+        "x-enum-varnames": [
+          "Rectangle",
+          "Ellipse",
+          "RoundedRectangle"
+        ],
+        "x-enumNames": [
+          "Rectangle",
+          "Ellipse",
+          "RoundedRectangle"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Rectangle",
+          "Ellipse",
+          "RoundedRectangle"
+        ]
+      },
+      "PolylineAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A closed multi-point polygon drawn on a page.",
+            "additionalProperties": false,
+            "properties": {
+              "points": {
+                "type": "array",
+                "description": "The ordered vertices of the polygon.",
+                "nullable": true,
+                "items": {
+                  "$ref": "#/components/schemas/AnnotationPoint"
+                }
+              },
+              "lineStyle": {
+                "description": "The border stroke style.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineStyle"
+                  }
+                ]
+              },
+              "fillColor": {
+                "type": "string",
+                "description": "The fill color as an RGB hex string; null if not filled.",
+                "nullable": true
+              },
+              "fillStyle": {
+                "description": "Whether the polygon is filled.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/FillStyle"
+                  }
+                ]
+              },
+              "color": {
+                "type": "string",
+                "description": "The border color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "thickness": {
+                "type": "integer",
+                "description": "The border thickness in pixels.",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the polygon as a percentage (0-100).",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "FillStyle": {
+        "type": "string",
+        "description": "Whether a closed shape is filled.",
+        "x-enum-names": [
+          "None",
+          "Solid"
+        ],
+        "x-enum-varnames": [
+          "None",
+          "Solid"
+        ],
+        "x-enumNames": [
+          "None",
+          "Solid"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null
+        ],
+        "enum": [
+          "None",
+          "Solid"
+        ]
+      },
+      "CalloutAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A text box with a pointer leading to a focus point on the page.",
+            "additionalProperties": false,
+            "properties": {
+              "boxCoordinates": {
+                "description": "The bounding rectangle of the callout's text box.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationRectangle"
+                  }
+                ]
+              },
+              "focusPosition": {
+                "description": "The point the callout pointer leads to.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "fillColor": {
+                "type": "string",
+                "description": "The fill color as an RGB hex string; null if not filled.",
+                "nullable": true
+              },
+              "borderColor": {
+                "type": "string",
+                "description": "The border and pointer color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "borderStyle": {
+                "description": "The border stroke style.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineStyle"
+                  }
+                ]
+              },
+              "borderThickness": {
+                "type": "integer",
+                "description": "The border thickness in pixels.",
+                "format": "int32"
+              },
+              "focusStyle": {
+                "description": "The cap style at the focus end of the pointer.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineEndingStyle"
+                  }
+                ]
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the callout as a percentage (0-100).",
+                "format": "int32"
+              },
+              "textSize": {
+                "type": "integer",
+                "description": "The font size of the text in points.",
+                "format": "int32"
+              },
+              "text": {
+                "type": "string",
+                "description": "The text displayed in the callout.",
+                "nullable": true
+              },
+              "direction": {
+                "description": "The reading direction of the text.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/TextDirection"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "StampAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A placement of a catalog stamp on a page. The stamp image itself is defined by the\ncatalog entry referenced by StampId.",
+            "additionalProperties": false,
+            "properties": {
+              "stampId": {
+                "type": "integer",
+                "description": "The ID of the catalog stamp placed; 0 when the stamp carries its own inline bitmap.",
+                "format": "int32"
+              },
+              "coordinates": {
+                "description": "The rectangle the stamp is drawn into.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationRectangle"
+                  }
+                ]
+              },
+              "position": {
+                "description": "The top-left position of the stamp on the page.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AnnotationPoint"
+                  }
+                ]
+              },
+              "color": {
+                "type": "string",
+                "description": "The render color of the stamp as an RGB hex string (for example, \"#000000\"); null if transparent.",
+                "nullable": true
+              },
+              "rotation": {
+                "type": "integer",
+                "description": "The clockwise rotation of the stamp in degrees (0-359).",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the stamp as a percentage (0-100).",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "FreeHandAnnotation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Annotation"
+          },
+          {
+            "type": "object",
+            "description": "A freehand-drawn multi-point line on a page.",
+            "additionalProperties": false,
+            "properties": {
+              "points": {
+                "type": "array",
+                "description": "The ordered points of the freehand stroke.",
+                "nullable": true,
+                "items": {
+                  "$ref": "#/components/schemas/AnnotationPoint"
+                }
+              },
+              "lineStyle": {
+                "description": "The stroke style.",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LineStyle"
+                  }
+                ]
+              },
+              "color": {
+                "type": "string",
+                "description": "The stroke color as an RGB hex string; null if transparent.",
+                "nullable": true
+              },
+              "thickness": {
+                "type": "integer",
+                "description": "The stroke thickness in pixels.",
+                "format": "int32"
+              },
+              "opacity": {
+                "type": "integer",
+                "description": "The opacity of the stroke as a percentage (0-100).",
+                "format": "int32"
+              }
+            }
+          }
+        ]
       },
       "ProblemDetails": {
         "type": "object",
@@ -11677,6 +15242,78 @@
           }
         }
       },
+      "AnnotationReason": {
+        "type": "object",
+        "description": "A repository-defined reason that can be associated with a redaction annotation.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The ID of the annotation reason.",
+            "format": "int32"
+          },
+          "text": {
+            "type": "string",
+            "description": "The display text of the annotation reason.",
+            "nullable": true
+          }
+        }
+      },
+      "AnnotationReasonRequest": {
+        "type": "object",
+        "description": "Request body for creating or updating an annotation (redaction) reason.",
+        "additionalProperties": false,
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The display text of the annotation reason.",
+            "nullable": true
+          }
+        }
+      },
+      "AttributeCollectionResponse": {
+        "type": "object",
+        "description": "Response containing a collection of Attribute.",
+        "additionalProperties": false,
+        "properties": {
+          "@odata.nextLink": {
+            "type": "string",
+            "description": "A URL to retrieve the next page of the requested collection.",
+            "nullable": true
+          },
+          "@odata.count": {
+            "type": "integer",
+            "description": "The total count of items within a collection.",
+            "format": "int32",
+            "nullable": true
+          },
+          "value": {
+            "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/Attribute"
+            }
+          }
+        }
+      },
+      "Attribute": {
+        "type": "object",
+        "description": "Represents a trustee attribute.",
+        "additionalProperties": false,
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The attribute key.",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "description": "The attribute value.",
+            "nullable": true
+          }
+        }
+      },
       "AuditReasonCollectionResponse": {
         "type": "object",
         "description": "Response containing a collection of AuditReason.",
@@ -11695,6 +15332,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/AuditReason"
@@ -12040,6 +15678,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/FieldDefinition"
@@ -12529,6 +16168,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/LinkDefinition"
@@ -13655,6 +17295,7 @@
         "properties": {
           "value": {
             "type": "string",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true
           }
         }
@@ -13772,6 +17413,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Entry"
@@ -13797,6 +17439,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Field"
@@ -13837,6 +17480,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Tag"
@@ -13956,6 +17600,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Link"
@@ -14336,6 +17981,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/PageInfoResponse"
@@ -14521,55 +18167,11 @@
             "nullable": true
           },
           "extent": {
-            "description": "The lock extent. Defaults to All when omitted.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/LockExtent"
-              }
-            ]
+            "type": "string",
+            "description": "The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted.",
+            "nullable": true
           }
         }
-      },
-      "LockExtent": {
-        "type": "string",
-        "description": "The portion of a document that a persistent lock covers.",
-        "x-enum-names": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-varnames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enumNames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-descriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "x-enumDescriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "enum": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ]
       },
       "CheckOutDocumentRequest": {
         "type": "object",
@@ -14607,6 +18209,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Repository"
@@ -14716,6 +18319,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/SearchContextHit"
@@ -14934,6 +18538,98 @@
           }
         }
       },
+      "Stamp": {
+        "type": "object",
+        "description": "A stamp in the repository stamp catalog. The stamp image is retrieved separately as a PNG.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The ID of the stamp.",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the stamp.",
+            "nullable": true
+          },
+          "isPublic": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the stamp is public (shared) rather than personal."
+          },
+          "owner": {
+            "type": "string",
+            "description": "The security identifier (SID) of the stamp's owner.",
+            "nullable": true
+          },
+          "customData": {
+            "type": "string",
+            "description": "Optional application-defined custom data stored with the stamp.",
+            "nullable": true
+          },
+          "imageWidth": {
+            "type": "integer",
+            "description": "The width of the stamp image in pixels.",
+            "format": "int32"
+          },
+          "imageHeight": {
+            "type": "integer",
+            "description": "The height of the stamp image in pixels.",
+            "format": "int32"
+          }
+        }
+      },
+      "StampScope": {
+        "type": "integer",
+        "description": "Which stamps to list.",
+        "x-enum-names": [
+          "Public",
+          "Personal",
+          "All"
+        ],
+        "x-enum-varnames": [
+          "Public",
+          "Personal",
+          "All"
+        ],
+        "x-enumNames": [
+          "Public",
+          "Personal",
+          "All"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          0,
+          1,
+          2
+        ]
+      },
+      "UpdateStampRequest": {
+        "type": "object",
+        "description": "Request body for updating a stamp's metadata. The stamp image cannot be changed after creation.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new display name of the stamp. Omit to leave unchanged.",
+            "nullable": true
+          },
+          "customData": {
+            "type": "string",
+            "description": "New custom data for the stamp. Omit to leave unchanged.",
+            "nullable": true
+          }
+        }
+      },
       "TagDefinitionCollectionResponse": {
         "type": "object",
         "description": "Response containing a collection of TagDefinition.",
@@ -14952,6 +18648,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TagDefinition"
@@ -15006,6 +18703,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TaskProgress"
@@ -15189,6 +18887,7 @@
         "properties": {
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/CancelTaskResult"
@@ -15238,6 +18937,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateDefinition"
@@ -15263,6 +18963,7 @@
           },
           "value": {
             "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateFieldDefinition"
@@ -15542,8 +19243,8 @@
         "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>https://api.laserfiche.com/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
         "flows": {
           "authorizationCode": {
-            "authorizationUrl": "https://signin.laserfiche.com/oauth/Authorize",
-            "tokenUrl": "https://signin.laserfiche.com/oauth/Token",
+            "authorizationUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Authorize",
+            "tokenUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Token",
             "scopes": {
               "repository.Read": "Allows the app to read the content of Laserfiche repositories on behalf of the signed-in user.",
               "repository.Write": "Allows the app to modify the content of Laserfiche repositories on behalf of the signed-in user."

--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -9,9 +9,6 @@
   "servers": [
     {
       "url": "https://api.laserfiche.com/repository"
-    },
-    {
-      "url": "https://api.laserfiche.com/repository"
     }
   ],
   "paths": {
@@ -10931,6 +10928,23 @@
               "type": "string"
             },
             "x-position": 1
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "isPublic",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 3
           }
         ],
         "requestBody": {
@@ -11338,7 +11352,7 @@
         "tags": [
           "Stamps"
         ],
-        "summary": "- Use `scope` to indicate whether the stamp is public or personal. An optional `color` (#RRGGBB) recolors the image.\n- Required OAuth scope: repository.Read",
+        "summary": "- Only public (common) stamps are returned. Personal stamps are not served by this endpoint and return 404.\n- An optional `color` (#RRGGBB) recolors the image: black pixels become the color, white becomes transparent.\n- Required OAuth scope: repository.Read",
         "operationId": "GetStampImage",
         "parameters": [
           {
@@ -11361,26 +11375,13 @@
             "x-position": 2
           },
           {
-            "name": "scope",
-            "in": "query",
-            "schema": {
-              "default": 0,
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/StampScope"
-                }
-              ]
-            },
-            "x-position": 3
-          },
-          {
             "name": "color",
             "in": "query",
             "schema": {
               "type": "string",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 3
           },
           {
             "name": "$select",
@@ -11390,7 +11391,7 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 5
+            "x-position": 4
           }
         ],
         "responses": {
@@ -19240,7 +19241,7 @@
       },
       "OAuth2 Authorization Code Flow": {
         "type": "oauth2",
-        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>https://api.laserfiche.com/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
+        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>http://localhost:11211/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
         "flows": {
           "authorizationCode": {
             "authorizationUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Authorize",

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -10276,10 +10276,12 @@ export interface IStampsClient {
      * - Send the image as multipart/form-data under the form field "file", with "name" and "isPublic" form fields. The service converts the image to the repository's internal format.
     - Creating a public stamp requires the stamp-management privilege; personal stamps require no special privilege.
     - Required OAuth scope: repository.Write
+     * @param args.name (optional) 
+     * @param args.isPublic (optional) 
      * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
      * @returns Successfully created the stamp. Returned the created stamp.
      */
-    createStamp(args: { repositoryId: string, file?: FileParameter | undefined }): Promise<Stamp>;
+    createStamp(args: { repositoryId: string, name?: string | null | undefined, isPublic?: boolean | undefined, file?: FileParameter | undefined }): Promise<Stamp>;
 
     /**
      * - Required OAuth scope: repository.Read
@@ -10303,14 +10305,14 @@ export interface IStampsClient {
     deleteStamp(args: { repositoryId: string, stampId: number }): Promise<void>;
 
     /**
-     * - Use `scope` to indicate whether the stamp is public or personal. An optional `color` (#RRGGBB) recolors the image.
+     * - Only public (common) stamps are returned. Personal stamps are not served by this endpoint and return 404.
+    - An optional `color` (#RRGGBB) recolors the image: black pixels become the color, white becomes transparent.
     - Required OAuth scope: repository.Read
-     * @param args.scope (optional) 
      * @param args.color (optional) 
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the stamp image as a PNG.
      */
-    getStampImage(args: { repositoryId: string, stampId: number, scope?: StampScope | undefined, color?: string | null | undefined, select?: string | null | undefined }): Promise<FileResponse>;
+    getStampImage(args: { repositoryId: string, stampId: number, color?: string | null | undefined, select?: string | null | undefined }): Promise<FileResponse>;
 }
 
 export class StampsClient implements IStampsClient {
@@ -10428,15 +10430,23 @@ export class StampsClient implements IStampsClient {
      * - Send the image as multipart/form-data under the form field "file", with "name" and "isPublic" form fields. The service converts the image to the repository's internal format.
     - Creating a public stamp requires the stamp-management privilege; personal stamps require no special privilege.
     - Required OAuth scope: repository.Write
+     * @param args.name (optional) 
+     * @param args.isPublic (optional) 
      * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
      * @returns Successfully created the stamp. Returned the created stamp.
      */
-    createStamp(args: { repositoryId: string, file?: FileParameter | undefined }): Promise<Stamp> {
-        let { repositoryId, file } = args;
-        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps";
+    createStamp(args: { repositoryId: string, name?: string | null | undefined, isPublic?: boolean | undefined, file?: FileParameter | undefined }): Promise<Stamp> {
+        let { repositoryId, name, isPublic, file } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
         url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (name !== undefined && name !== null)
+            url_ += "name=" + encodeURIComponent("" + name) + "&";
+        if (isPublic === null)
+            throw new Error("The parameter 'isPublic' cannot be null.");
+        else if (isPublic !== undefined)
+            url_ += "isPublic=" + encodeURIComponent("" + isPublic) + "&";
         url_ = url_.replace(/[?&]$/, "");
 
         const content_ = new FormData();
@@ -10778,15 +10788,15 @@ export class StampsClient implements IStampsClient {
     }
 
     /**
-     * - Use `scope` to indicate whether the stamp is public or personal. An optional `color` (#RRGGBB) recolors the image.
+     * - Only public (common) stamps are returned. Personal stamps are not served by this endpoint and return 404.
+    - An optional `color` (#RRGGBB) recolors the image: black pixels become the color, white becomes transparent.
     - Required OAuth scope: repository.Read
-     * @param args.scope (optional) 
      * @param args.color (optional) 
      * @param args.select (optional) Limits the properties returned in the result.
      * @returns Successfully returned the stamp image as a PNG.
      */
-    getStampImage(args: { repositoryId: string, stampId: number, scope?: StampScope | undefined, color?: string | null | undefined, select?: string | null | undefined }): Promise<FileResponse> {
-        let { repositoryId, stampId, scope, color, select } = args;
+    getStampImage(args: { repositoryId: string, stampId: number, color?: string | null | undefined, select?: string | null | undefined }): Promise<FileResponse> {
+        let { repositoryId, stampId, color, select } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps/{stampId}/Image?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -10794,10 +10804,6 @@ export class StampsClient implements IStampsClient {
         if (stampId === undefined || stampId === null)
             throw new Error("The parameter 'stampId' must be defined.");
         url_ = url_.replace("{stampId}", encodeURIComponent("" + stampId));
-        if (scope === null)
-            throw new Error("The parameter 'scope' cannot be null.");
-        else if (scope !== undefined)
-            url_ += "scope=" + encodeURIComponent("" + scope) + "&";
         if (color !== undefined && color !== null)
             url_ += "color=" + encodeURIComponent("" + color) + "&";
         if (select !== undefined && select !== null)

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -20,6 +20,1418 @@ import {
   GetAccessTokenResponse
 } from '@laserfiche/lf-api-client-core';
 
+export interface IAnnotationsClient {
+
+    /**
+     * - Returns every annotation on every page of the document, as a polymorphic list keyed by annotation type.
+    - Requires the "see annotations" entry right; redaction content is only revealed to callers with the "see through redactions" right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the annotations on the document.
+     */
+    listDocumentAnnotations(args: { repositoryId: string, entryId: number, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<Annotation[]>;
+
+    /**
+     * - Returns the annotations on the requested page, as a polymorphic list keyed by annotation type.
+    - Requires the "see annotations" entry right; redaction content is only revealed to callers with the "see through redactions" right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.pageNumber The 1-based page number.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the annotations on the page.
+     */
+    listPageAnnotations(args: { repositoryId: string, entryId: number, pageNumber: number, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<Annotation[]>;
+
+    /**
+     * - The request body is a polymorphic annotation discriminated by `annotationType`; supply the writable members for that type.
+    - For attachment and bitmap annotations, create the annotation first, then upload its binary content via the dedicated sub-resource.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully created the annotation. Returned the created annotation.
+     */
+    createAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, request: Annotation }): Promise<Annotation>;
+
+    /**
+     * - Returns the annotation, typed by annotation type.
+    - Requires the "see annotations" entry right; redaction content is only revealed to callers with the "see through redactions" right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.pageNumber The 1-based page number.
+     * @param args.itemId The annotation item ID, unique within the page.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the requested annotation.
+     */
+    getAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, select?: string | null | undefined }): Promise<Annotation>;
+
+    /**
+     * - Supply only the members to change; omitted members are left unchanged. The `annotationType` must match the existing annotation.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully updated the annotation. Returned the updated annotation.
+     */
+    updateAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, request: Annotation }): Promise<Annotation>;
+
+    /**
+     * - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully deleted the annotation.
+     */
+    deleteAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number }): Promise<void>;
+
+    /**
+     * - Streams the attached file. Fails with a bad request if the annotation is not an attachment.
+    - Requires the "see annotations" entry right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.pageNumber The 1-based page number.
+     * @param args.itemId The attachment annotation's item ID.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the content of the attachment annotation.
+     */
+    getAnnotationAttachment(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, select?: string | null | undefined }): Promise<FileResponse>;
+
+    /**
+     * - Send the file as multipart/form-data under the form field "file". The annotation must already exist and be an attachment annotation.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
+     * @returns Successfully uploaded the attachment content.
+     */
+    uploadAnnotationAttachment(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, file?: FileParameter | undefined }): Promise<void>;
+
+    /**
+     * - Returns the redaction reasons defined in the repository.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the repository's annotation reasons.
+     */
+    listAnnotationReasons(args: { repositoryId: string, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<AnnotationReason[]>;
+
+    /**
+     * - Required OAuth scope: repository.Write
+     * @returns Successfully created the annotation reason. Returned the created reason.
+     */
+    createAnnotationReason(args: { repositoryId: string, request: AnnotationReasonRequest }): Promise<AnnotationReason>;
+
+    /**
+     * - Send the image as multipart/form-data under the form field "file". The annotation must already exist and be a bitmap annotation.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
+     * @returns Successfully uploaded the bitmap annotation image.
+     */
+    uploadAnnotationImage(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, file?: FileParameter | undefined }): Promise<void>;
+
+    /**
+     * - Required OAuth scope: repository.Write
+     * @returns Successfully updated the annotation reason. Returned the updated reason.
+     */
+    updateAnnotationReason(args: { repositoryId: string, reasonId: number, request: AnnotationReasonRequest }): Promise<AnnotationReason>;
+
+    /**
+     * - When `force` is false, deleting a reason that is in use fails.
+    - Required OAuth scope: repository.Write
+     * @param args.force (optional) 
+     * @returns Successfully deleted the annotation reason.
+     */
+    deleteAnnotationReason(args: { repositoryId: string, reasonId: number, force?: boolean | undefined }): Promise<void>;
+}
+
+export class AnnotationsClient implements IAnnotationsClient {
+    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : window as any;
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+    }
+
+    /**
+     * - Returns every annotation on every page of the document, as a polymorphic list keyed by annotation type.
+    - Requires the "see annotations" entry right; redaction content is only revealed to callers with the "see through redactions" right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the annotations on the document.
+     */
+    listDocumentAnnotations(args: { repositoryId: string, entryId: number, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<Annotation[]> {
+        let { repositoryId, entryId, select, orderby, count } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Annotations?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        if (orderby !== undefined && orderby !== null)
+            url_ += "$orderby=" + encodeURIComponent("" + orderby) + "&";
+        if (count === null)
+            throw new Error("The parameter 'count' cannot be null.");
+        else if (count !== undefined)
+            url_ += "$count=" + encodeURIComponent("" + count) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processListDocumentAnnotations(_response);
+        });
+    }
+
+    protected processListDocumentAnnotations(response: Response): Promise<Annotation[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(Annotation.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Annotation[]>(null as any);
+    }
+
+    /**
+     * - Returns the annotations on the requested page, as a polymorphic list keyed by annotation type.
+    - Requires the "see annotations" entry right; redaction content is only revealed to callers with the "see through redactions" right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.pageNumber The 1-based page number.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the annotations on the page.
+     */
+    listPageAnnotations(args: { repositoryId: string, entryId: number, pageNumber: number, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<Annotation[]> {
+        let { repositoryId, entryId, pageNumber, select, orderby, count } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        if (orderby !== undefined && orderby !== null)
+            url_ += "$orderby=" + encodeURIComponent("" + orderby) + "&";
+        if (count === null)
+            throw new Error("The parameter 'count' cannot be null.");
+        else if (count !== undefined)
+            url_ += "$count=" + encodeURIComponent("" + count) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processListPageAnnotations(_response);
+        });
+    }
+
+    protected processListPageAnnotations(response: Response): Promise<Annotation[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(Annotation.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Annotation[]>(null as any);
+    }
+
+    /**
+     * - The request body is a polymorphic annotation discriminated by `annotationType`; supply the writable members for that type.
+    - For attachment and bitmap annotations, create the annotation first, then upload its binary content via the dedicated sub-resource.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully created the annotation. Returned the created annotation.
+     */
+    createAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, request: Annotation }): Promise<Annotation> {
+        let { repositoryId, entryId, pageNumber, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processCreateAnnotation(_response);
+        });
+    }
+
+    protected processCreateAnnotation(response: Response): Promise<Annotation> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = Annotation.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Annotation>(null as any);
+    }
+
+    /**
+     * - Returns the annotation, typed by annotation type.
+    - Requires the "see annotations" entry right; redaction content is only revealed to callers with the "see through redactions" right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.pageNumber The 1-based page number.
+     * @param args.itemId The annotation item ID, unique within the page.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the requested annotation.
+     */
+    getAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, select?: string | null | undefined }): Promise<Annotation> {
+        let { repositoryId, entryId, pageNumber, itemId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (itemId === undefined || itemId === null)
+            throw new Error("The parameter 'itemId' must be defined.");
+        url_ = url_.replace("{itemId}", encodeURIComponent("" + itemId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetAnnotation(_response);
+        });
+    }
+
+    protected processGetAnnotation(response: Response): Promise<Annotation> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = Annotation.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Annotation>(null as any);
+    }
+
+    /**
+     * - Supply only the members to change; omitted members are left unchanged. The `annotationType` must match the existing annotation.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully updated the annotation. Returned the updated annotation.
+     */
+    updateAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, request: Annotation }): Promise<Annotation> {
+        let { repositoryId, entryId, pageNumber, itemId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (itemId === undefined || itemId === null)
+            throw new Error("The parameter 'itemId' must be defined.");
+        url_ = url_.replace("{itemId}", encodeURIComponent("" + itemId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateAnnotation(_response);
+        });
+    }
+
+    protected processUpdateAnnotation(response: Response): Promise<Annotation> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = Annotation.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Annotation>(null as any);
+    }
+
+    /**
+     * - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully deleted the annotation.
+     */
+    deleteAnnotation(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number }): Promise<void> {
+        let { repositoryId, entryId, pageNumber, itemId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (itemId === undefined || itemId === null)
+            throw new Error("The parameter 'itemId' must be defined.");
+        url_ = url_.replace("{itemId}", encodeURIComponent("" + itemId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteAnnotation(_response);
+        });
+    }
+
+    protected processDeleteAnnotation(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * - Streams the attached file. Fails with a bad request if the annotation is not an attachment.
+    - Requires the "see annotations" entry right.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.entryId The document entry ID.
+     * @param args.pageNumber The 1-based page number.
+     * @param args.itemId The attachment annotation's item ID.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the content of the attachment annotation.
+     */
+    getAnnotationAttachment(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, select?: string | null | undefined }): Promise<FileResponse> {
+        let { repositoryId, entryId, pageNumber, itemId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Attachment?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (itemId === undefined || itemId === null)
+            throw new Error("The parameter 'itemId' must be defined.");
+        url_ = url_.replace("{itemId}", encodeURIComponent("" + itemId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/octet-stream"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetAnnotationAttachment(_response);
+        });
+    }
+
+    protected processGetAnnotationAttachment(response: Response): Promise<FileResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200 || status === 206) {
+            const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
+            let fileNameMatch = contentDisposition ? /filename\*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+            let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
+            if (fileName) {
+                fileName = decodeURIComponent(fileName);
+            } else {
+                fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+                fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+            }
+            return response.blob().then(blob => { return { fileName: fileName, data: blob, status: status, headers: _headers }; });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FileResponse>(null as any);
+    }
+
+    /**
+     * - Send the file as multipart/form-data under the form field "file". The annotation must already exist and be an attachment annotation.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
+     * @returns Successfully uploaded the attachment content.
+     */
+    uploadAnnotationAttachment(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, file?: FileParameter | undefined }): Promise<void> {
+        let { repositoryId, entryId, pageNumber, itemId, file } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Attachment";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (itemId === undefined || itemId === null)
+            throw new Error("The parameter 'itemId' must be defined.");
+        url_ = url_.replace("{itemId}", encodeURIComponent("" + itemId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = new FormData();
+        if (file === null || file === undefined)
+            throw new Error("The parameter 'file' cannot be null.");
+        else
+            content_.append("file", file.data, file.fileName ? file.fileName : "file");
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUploadAnnotationAttachment(_response);
+        });
+    }
+
+    protected processUploadAnnotationAttachment(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * - Returns the redaction reasons defined in the repository.
+    - Required OAuth scope: repository.Read
+     * @param args.repositoryId The requested repository ID.
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the repository's annotation reasons.
+     */
+    listAnnotationReasons(args: { repositoryId: string, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<AnnotationReason[]> {
+        let { repositoryId, select, orderby, count } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/AnnotationReasons?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        if (orderby !== undefined && orderby !== null)
+            url_ += "$orderby=" + encodeURIComponent("" + orderby) + "&";
+        if (count === null)
+            throw new Error("The parameter 'count' cannot be null.");
+        else if (count !== undefined)
+            url_ += "$count=" + encodeURIComponent("" + count) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processListAnnotationReasons(_response);
+        });
+    }
+
+    protected processListAnnotationReasons(response: Response): Promise<AnnotationReason[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(AnnotationReason.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AnnotationReason[]>(null as any);
+    }
+
+    /**
+     * - Required OAuth scope: repository.Write
+     * @returns Successfully created the annotation reason. Returned the created reason.
+     */
+    createAnnotationReason(args: { repositoryId: string, request: AnnotationReasonRequest }): Promise<AnnotationReason> {
+        let { repositoryId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/AnnotationReasons";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processCreateAnnotationReason(_response);
+        });
+    }
+
+    protected processCreateAnnotationReason(response: Response): Promise<AnnotationReason> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AnnotationReason.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AnnotationReason>(null as any);
+    }
+
+    /**
+     * - Send the image as multipart/form-data under the form field "file". The annotation must already exist and be a bitmap annotation.
+    - Requires the "annotate" entry right.
+    - Required OAuth scope: repository.Write
+     * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
+     * @returns Successfully uploaded the bitmap annotation image.
+     */
+    uploadAnnotationImage(args: { repositoryId: string, entryId: number, pageNumber: number, itemId: number, file?: FileParameter | undefined }): Promise<void> {
+        let { repositoryId, entryId, pageNumber, itemId, file } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Image";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (entryId === undefined || entryId === null)
+            throw new Error("The parameter 'entryId' must be defined.");
+        url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (pageNumber === undefined || pageNumber === null)
+            throw new Error("The parameter 'pageNumber' must be defined.");
+        url_ = url_.replace("{pageNumber}", encodeURIComponent("" + pageNumber));
+        if (itemId === undefined || itemId === null)
+            throw new Error("The parameter 'itemId' must be defined.");
+        url_ = url_.replace("{itemId}", encodeURIComponent("" + itemId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = new FormData();
+        if (file === null || file === undefined)
+            throw new Error("The parameter 'file' cannot be null.");
+        else
+            content_.append("file", file.data, file.fileName ? file.fileName : "file");
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PUT",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUploadAnnotationImage(_response);
+        });
+    }
+
+    protected processUploadAnnotationImage(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested document, page, or annotation was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * - Required OAuth scope: repository.Write
+     * @returns Successfully updated the annotation reason. Returned the updated reason.
+     */
+    updateAnnotationReason(args: { repositoryId: string, reasonId: number, request: AnnotationReasonRequest }): Promise<AnnotationReason> {
+        let { repositoryId, reasonId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/AnnotationReasons/{reasonId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (reasonId === undefined || reasonId === null)
+            throw new Error("The parameter 'reasonId' must be defined.");
+        url_ = url_.replace("{reasonId}", encodeURIComponent("" + reasonId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateAnnotationReason(_response);
+        });
+    }
+
+    protected processUpdateAnnotationReason(response: Response): Promise<AnnotationReason> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = AnnotationReason.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<AnnotationReason>(null as any);
+    }
+
+    /**
+     * - When `force` is false, deleting a reason that is in use fails.
+    - Required OAuth scope: repository.Write
+     * @param args.force (optional) 
+     * @returns Successfully deleted the annotation reason.
+     */
+    deleteAnnotationReason(args: { repositoryId: string, reasonId: number, force?: boolean | undefined }): Promise<void> {
+        let { repositoryId, reasonId, force } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/AnnotationReasons/{reasonId}?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (reasonId === undefined || reasonId === null)
+            throw new Error("The parameter 'reasonId' must be defined.");
+        url_ = url_.replace("{reasonId}", encodeURIComponent("" + reasonId));
+        if (force === null)
+            throw new Error("The parameter 'force' cannot be null.");
+        else if (force !== undefined)
+            url_ += "force=" + encodeURIComponent("" + force) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteAnnotationReason(_response);
+        });
+    }
+
+    protected processDeleteAnnotationReason(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("Not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+}
+
 export interface IAttributesClient {
 
     /**
@@ -8847,6 +10259,628 @@ export class SimpleSearchesClient implements ISimpleSearchesClient {
     }
 }
 
+export interface IStampsClient {
+
+    /**
+     * - Use `scope` to select public, personal, or all stamps. The image bytes are not included; fetch them from the stamp's Image sub-resource.
+    - Required OAuth scope: repository.Read
+     * @param args.scope (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the repository's stamps.
+     */
+    listStamps(args: { repositoryId: string, scope?: StampScope | undefined, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<Stamp[]>;
+
+    /**
+     * - Send the image as multipart/form-data under the form field "file", with "name" and "isPublic" form fields. The service converts the image to the repository's internal format.
+    - Creating a public stamp requires the stamp-management privilege; personal stamps require no special privilege.
+    - Required OAuth scope: repository.Write
+     * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
+     * @returns Successfully created the stamp. Returned the created stamp.
+     */
+    createStamp(args: { repositoryId: string, file?: FileParameter | undefined }): Promise<Stamp>;
+
+    /**
+     * - Required OAuth scope: repository.Read
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the stamp's metadata.
+     */
+    getStamp(args: { repositoryId: string, stampId: number, select?: string | null | undefined }): Promise<Stamp>;
+
+    /**
+     * - Managing a public stamp requires the stamp-management privilege.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully updated the stamp. Returned the updated stamp.
+     */
+    updateStamp(args: { repositoryId: string, stampId: number, request: UpdateStampRequest }): Promise<Stamp>;
+
+    /**
+     * - Deleting a public stamp requires the stamp-management privilege.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully deleted the stamp.
+     */
+    deleteStamp(args: { repositoryId: string, stampId: number }): Promise<void>;
+
+    /**
+     * - Use `scope` to indicate whether the stamp is public or personal. An optional `color` (#RRGGBB) recolors the image.
+    - Required OAuth scope: repository.Read
+     * @param args.scope (optional) 
+     * @param args.color (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the stamp image as a PNG.
+     */
+    getStampImage(args: { repositoryId: string, stampId: number, scope?: StampScope | undefined, color?: string | null | undefined, select?: string | null | undefined }): Promise<FileResponse>;
+}
+
+export class StampsClient implements IStampsClient {
+    private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
+    private baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
+        this.http = http ? http : window as any;
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
+    }
+
+    /**
+     * - Use `scope` to select public, personal, or all stamps. The image bytes are not included; fetch them from the stamp's Image sub-resource.
+    - Required OAuth scope: repository.Read
+     * @param args.scope (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @param args.orderby (optional) Specifies the order in which items are returned. The maximum number of expressions is 5.
+     * @param args.count (optional) Indicates whether the total count of items within a collection are returned in the result.
+     * @returns Successfully returned the repository's stamps.
+     */
+    listStamps(args: { repositoryId: string, scope?: StampScope | undefined, select?: string | null | undefined, orderby?: string | null | undefined, count?: boolean | undefined }): Promise<Stamp[]> {
+        let { repositoryId, scope, select, orderby, count } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (scope === null)
+            throw new Error("The parameter 'scope' cannot be null.");
+        else if (scope !== undefined)
+            url_ += "scope=" + encodeURIComponent("" + scope) + "&";
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        if (orderby !== undefined && orderby !== null)
+            url_ += "$orderby=" + encodeURIComponent("" + orderby) + "&";
+        if (count === null)
+            throw new Error("The parameter 'count' cannot be null.");
+        else if (count !== undefined)
+            url_ += "$count=" + encodeURIComponent("" + count) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processListStamps(_response);
+        });
+    }
+
+    protected processListStamps(response: Response): Promise<Stamp[]> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            if (Array.isArray(resultData200)) {
+                result200 = [] as any;
+                for (let item of resultData200)
+                    result200!.push(Stamp.fromJS(item));
+            }
+            else {
+                result200 = <any>null;
+            }
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Stamp[]>(null as any);
+    }
+
+    /**
+     * - Send the image as multipart/form-data under the form field "file", with "name" and "isPublic" form fields. The service converts the image to the repository's internal format.
+    - Creating a public stamp requires the stamp-management privilege; personal stamps require no special privilege.
+    - Required OAuth scope: repository.Write
+     * @param args.file (optional) The image file to upload. See https://doc.laserfiche.com/ for supported image file formats.
+     * @returns Successfully created the stamp. Returned the created stamp.
+     */
+    createStamp(args: { repositoryId: string, file?: FileParameter | undefined }): Promise<Stamp> {
+        let { repositoryId, file } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = new FormData();
+        if (file === null || file === undefined)
+            throw new Error("The parameter 'file' cannot be null.");
+        else
+            content_.append("file", file.data, file.fileName ? file.fileName : "file");
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "POST",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processCreateStamp(_response);
+        });
+    }
+
+    protected processCreateStamp(response: Response): Promise<Stamp> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = Stamp.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Stamp>(null as any);
+    }
+
+    /**
+     * - Required OAuth scope: repository.Read
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the stamp's metadata.
+     */
+    getStamp(args: { repositoryId: string, stampId: number, select?: string | null | undefined }): Promise<Stamp> {
+        let { repositoryId, stampId, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps/{stampId}?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (stampId === undefined || stampId === null)
+            throw new Error("The parameter 'stampId' must be defined.");
+        url_ = url_.replace("{stampId}", encodeURIComponent("" + stampId));
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetStamp(_response);
+        });
+    }
+
+    protected processGetStamp(response: Response): Promise<Stamp> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = Stamp.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested stamp was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Stamp>(null as any);
+    }
+
+    /**
+     * - Managing a public stamp requires the stamp-management privilege.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully updated the stamp. Returned the updated stamp.
+     */
+    updateStamp(args: { repositoryId: string, stampId: number, request: UpdateStampRequest }): Promise<Stamp> {
+        let { repositoryId, stampId, request } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps/{stampId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (stampId === undefined || stampId === null)
+            throw new Error("The parameter 'stampId' must be defined.");
+        url_ = url_.replace("{stampId}", encodeURIComponent("" + stampId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: RequestInit = {
+            body: content_,
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processUpdateStamp(_response);
+        });
+    }
+
+    protected processUpdateStamp(response: Response): Promise<Stamp> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200) {
+            return response.text().then((_responseText) => {
+            let result200: any = null;
+            let resultData200 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result200 = Stamp.fromJS(resultData200);
+            return result200;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested stamp was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<Stamp>(null as any);
+    }
+
+    /**
+     * - Deleting a public stamp requires the stamp-management privilege.
+    - Required OAuth scope: repository.Write
+     * @returns Successfully deleted the stamp.
+     */
+    deleteStamp(args: { repositoryId: string, stampId: number }): Promise<void> {
+        let { repositoryId, stampId } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps/{stampId}";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (stampId === undefined || stampId === null)
+            throw new Error("The parameter 'stampId' must be defined.");
+        url_ = url_.replace("{stampId}", encodeURIComponent("" + stampId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "DELETE",
+            headers: {
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processDeleteStamp(_response);
+        });
+    }
+
+    protected processDeleteStamp(response: Response): Promise<void> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 204) {
+            return response.text().then((_responseText) => {
+            return;
+            });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested stamp was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * - Use `scope` to indicate whether the stamp is public or personal. An optional `color` (#RRGGBB) recolors the image.
+    - Required OAuth scope: repository.Read
+     * @param args.scope (optional) 
+     * @param args.color (optional) 
+     * @param args.select (optional) Limits the properties returned in the result.
+     * @returns Successfully returned the stamp image as a PNG.
+     */
+    getStampImage(args: { repositoryId: string, stampId: number, scope?: StampScope | undefined, color?: string | null | undefined, select?: string | null | undefined }): Promise<FileResponse> {
+        let { repositoryId, stampId, scope, color, select } = args;
+        let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Stamps/{stampId}/Image?";
+        if (repositoryId === undefined || repositoryId === null)
+            throw new Error("The parameter 'repositoryId' must be defined.");
+        url_ = url_.replace("{repositoryId}", encodeURIComponent("" + repositoryId));
+        if (stampId === undefined || stampId === null)
+            throw new Error("The parameter 'stampId' must be defined.");
+        url_ = url_.replace("{stampId}", encodeURIComponent("" + stampId));
+        if (scope === null)
+            throw new Error("The parameter 'scope' cannot be null.");
+        else if (scope !== undefined)
+            url_ += "scope=" + encodeURIComponent("" + scope) + "&";
+        if (color !== undefined && color !== null)
+            url_ += "color=" + encodeURIComponent("" + color) + "&";
+        if (select !== undefined && select !== null)
+            url_ += "$select=" + encodeURIComponent("" + select) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: RequestInit = {
+            method: "GET",
+            headers: {
+                "Accept": "application/octet-stream"
+            }
+        };
+
+        return this.http.fetch(url_, options_).then((_response: Response) => {
+            return this.processGetStampImage(_response);
+        });
+    }
+
+    protected processGetStampImage(response: Response): Promise<FileResponse> {
+        const status = response.status;
+        let _headers: any = {}; if (response.headers && response.headers.forEach) { response.headers.forEach((v: any, k: any) => _headers[k] = v); };
+        if (status === 200 || status === 206) {
+            const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
+            let fileNameMatch = contentDisposition ? /filename\*=(?:(\\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+            let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
+            if (fileName) {
+                fileName = decodeURIComponent(fileName);
+            } else {
+                fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+                fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+            }
+            return response.blob().then(blob => { return { fileName: fileName, data: blob, status: status, headers: _headers }; });
+        } else if (status === 400) {
+            return response.text().then((_responseText) => {
+            let result400: any = null;
+            let resultData400 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result400 = ProblemDetails.fromJS(resultData400);
+            return throwException("Invalid or bad request.", status, _responseText, _headers, result400);
+            });
+        } else if (status === 401) {
+            return response.text().then((_responseText) => {
+            let result401: any = null;
+            let resultData401 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result401 = ProblemDetails.fromJS(resultData401);
+            return throwException("Access token is invalid or expired.", status, _responseText, _headers, result401);
+            });
+        } else if (status === 403) {
+            return response.text().then((_responseText) => {
+            let result403: any = null;
+            let resultData403 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result403 = ProblemDetails.fromJS(resultData403);
+            return throwException("Access denied for the operation.", status, _responseText, _headers, result403);
+            });
+        } else if (status === 404) {
+            return response.text().then((_responseText) => {
+            let result404: any = null;
+            let resultData404 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result404 = ProblemDetails.fromJS(resultData404);
+            return throwException("The requested stamp was not found.", status, _responseText, _headers, result404);
+            });
+        } else if (status === 429) {
+            return response.text().then((_responseText) => {
+            let result429: any = null;
+            let resultData429 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result429 = ProblemDetails.fromJS(resultData429);
+            return throwException("Rate limit is reached.", status, _responseText, _headers, result429);
+            });
+        } else if (status === 500) {
+            return response.text().then((_responseText) => {
+            let result500: any = null;
+            let resultData500 = _responseText === "" ? null : JSON.parse(_responseText, this.jsonParseReviver);
+            result500 = ProblemDetails.fromJS(resultData500);
+            return throwException("An unexpected server-side error occurred.", status, _responseText, _headers, result500);
+            });
+        } else if (status !== 200 && status !== 204) {
+            return response.text().then((_responseText) => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            });
+        }
+        return Promise.resolve<FileResponse>(null as any);
+    }
+}
+
 export interface ITagDefinitionsClient {
 
     /**
@@ -11340,17 +13374,313 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
     }
 }
 
-/** Response containing a collection of Attribute. */
-export class AttributeCollectionResponse implements IAttributeCollectionResponse {
-    /** A URL to retrieve the next page of the requested collection. */
-    odataNextLink?: string | undefined;
-    /** The total count of items within a collection. */
-    odataCount?: number | undefined;
-    value?: Attribute[] | undefined;
+export abstract class Annotation implements IAnnotation {
+    /** The identifier of the annotation, unique within its page. */
+    itemId?: number;
+    /** The ID of the document entry the annotation belongs to. */
+    entryId?: number;
+    /** The 1-based page number the annotation is on. */
+    pageNumber?: number;
+    /** The security identifier (SID) of the user that created the annotation. */
+    creator?: string | undefined;
+    /** The UTC time the annotation was created. */
+    createdTime?: Date;
+    /** The UTC time the annotation was last modified. */
+    lastModifiedTime?: Date;
+    /** A boolean indicating whether the annotation is read-only (for example, on an archived version). */
+    isReadOnly?: boolean;
+    /** A boolean indicating whether the annotation is protected so that only its creator can modify it. */
+    isProtected?: boolean;
+    /** Controls who can see the annotation. */
+    visibility?: AnnotationVisibility;
+    /** An optional comment on the annotation. */
+    comment?: string | undefined;
+    /** Optional application-defined custom data stored with the annotation. */
+    customData?: string | undefined;
+    /** The z-order of the annotation; higher values draw on top. */
+    zOrder?: number;
+    /** The ID of the redaction reason associated with the annotation, if any. */
+    reasonId?: number | undefined;
+    /** How the annotation participates in access control. */
+    accessType?: AnnotationAccessControlType;
+    protected _discriminator: string;
 
     
     
-    constructor(data?: IAttributeCollectionResponse) {
+    constructor(data?: IAnnotation) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Annotation";
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.itemId = _data["itemId"];
+            this.entryId = _data["entryId"];
+            this.pageNumber = _data["pageNumber"];
+            this.creator = _data["creator"];
+            this.createdTime = _data["createdTime"] ? new Date(_data["createdTime"].toString()) : <any>undefined;
+            this.lastModifiedTime = _data["lastModifiedTime"] ? new Date(_data["lastModifiedTime"].toString()) : <any>undefined;
+            this.isReadOnly = _data["isReadOnly"];
+            this.isProtected = _data["isProtected"];
+            this.visibility = _data["visibility"];
+            this.comment = _data["comment"];
+            this.customData = _data["customData"];
+            this.zOrder = _data["zOrder"];
+            this.reasonId = _data["reasonId"];
+            this.accessType = _data["accessType"];
+        }
+    }
+
+    static fromJS(data: any): Annotation {
+        data = typeof data === 'object' ? data : {};
+        if (data["annotationType"] === "Highlight") {
+            let result = new HighlightAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Redaction") {
+            let result = new RedactionAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Strikeout") {
+            let result = new StrikeoutAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Underline") {
+            let result = new UnderlineAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Note") {
+            let result = new NoteAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Attachment") {
+            let result = new AttachmentAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "TextBox") {
+            let result = new TextBoxAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Bitmap") {
+            let result = new BitmapAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Line") {
+            let result = new LineAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Rectangle") {
+            let result = new RectangleAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Polyline") {
+            let result = new PolylineAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Callout") {
+            let result = new CalloutAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "Stamp") {
+            let result = new StampAnnotation();
+            result.init(data);
+            return result;
+        }
+        if (data["annotationType"] === "FreeHand") {
+            let result = new FreeHandAnnotation();
+            result.init(data);
+            return result;
+        }
+        throw new Error("The abstract class 'Annotation' cannot be instantiated.");
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["annotationType"] = this._discriminator;
+        data["itemId"] = this.itemId;
+        data["entryId"] = this.entryId;
+        data["pageNumber"] = this.pageNumber;
+        data["creator"] = this.creator;
+        data["createdTime"] = this.createdTime ? this.createdTime.toISOString() : <any>undefined;
+        data["lastModifiedTime"] = this.lastModifiedTime ? this.lastModifiedTime.toISOString() : <any>undefined;
+        data["isReadOnly"] = this.isReadOnly;
+        data["isProtected"] = this.isProtected;
+        data["visibility"] = this.visibility;
+        data["comment"] = this.comment;
+        data["customData"] = this.customData;
+        data["zOrder"] = this.zOrder;
+        data["reasonId"] = this.reasonId;
+        data["accessType"] = this.accessType;
+        return data;
+    }
+}
+
+export interface IAnnotation {
+    /** The identifier of the annotation, unique within its page. */
+    itemId?: number;
+    /** The ID of the document entry the annotation belongs to. */
+    entryId?: number;
+    /** The 1-based page number the annotation is on. */
+    pageNumber?: number;
+    /** The security identifier (SID) of the user that created the annotation. */
+    creator?: string | undefined;
+    /** The UTC time the annotation was created. */
+    createdTime?: Date;
+    /** The UTC time the annotation was last modified. */
+    lastModifiedTime?: Date;
+    /** A boolean indicating whether the annotation is read-only (for example, on an archived version). */
+    isReadOnly?: boolean;
+    /** A boolean indicating whether the annotation is protected so that only its creator can modify it. */
+    isProtected?: boolean;
+    /** Controls who can see the annotation. */
+    visibility?: AnnotationVisibility;
+    /** An optional comment on the annotation. */
+    comment?: string | undefined;
+    /** Optional application-defined custom data stored with the annotation. */
+    customData?: string | undefined;
+    /** The z-order of the annotation; higher values draw on top. */
+    zOrder?: number;
+    /** The ID of the redaction reason associated with the annotation, if any. */
+    reasonId?: number | undefined;
+    /** How the annotation participates in access control. */
+    accessType?: AnnotationAccessControlType;
+}
+
+/** The kind of a document annotation. Used as the discriminator for the polymorphic Annotation response. */
+export enum AnnotationType {
+    Highlight = "Highlight",
+    Redaction = "Redaction",
+    Strikeout = "Strikeout",
+    Underline = "Underline",
+    Note = "Note",
+    Attachment = "Attachment",
+    TextBox = "TextBox",
+    Bitmap = "Bitmap",
+    Line = "Line",
+    Rectangle = "Rectangle",
+    Polyline = "Polyline",
+    Callout = "Callout",
+    Stamp = "Stamp",
+    FreeHand = "FreeHand",
+}
+
+/** Controls who can see an annotation. */
+export enum AnnotationVisibility {
+    CreatorAndOwner = "CreatorAndOwner",
+    Standard = "Standard",
+    AllUsers = "AllUsers",
+}
+
+/** How an annotation participates in access control. */
+export enum AnnotationAccessControlType {
+    None = "None",
+    Allow = "Allow",
+    Deny = "Deny",
+}
+
+/** Highlights one or more regions of a page. */
+export class HighlightAnnotation extends Annotation implements IHighlightAnnotation {
+    /** The highlight color as an RGB hex string (for example, "#FFFF00"); null if transparent. */
+    color?: string | undefined;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the highlight. */
+    rectangles?: AnnotationRectangle[] | undefined;
+
+    
+    
+    constructor(data?: IHighlightAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Highlight";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.color = _data["color"];
+            this.textStart = _data["textStart"];
+            this.textEnd = _data["textEnd"];
+            if (Array.isArray(_data["rectangles"])) {
+                this.rectangles = [] as any;
+                for (let item of _data["rectangles"])
+                    this.rectangles!.push(AnnotationRectangle.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): HighlightAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new HighlightAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["color"] = this.color;
+        data["textStart"] = this.textStart;
+        data["textEnd"] = this.textEnd;
+        if (Array.isArray(this.rectangles)) {
+            data["rectangles"] = [];
+            for (let item of this.rectangles)
+                data["rectangles"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** Highlights one or more regions of a page. */
+export interface IHighlightAnnotation extends IAnnotation {
+    /** The highlight color as an RGB hex string (for example, "#FFFF00"); null if transparent. */
+    color?: string | undefined;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the highlight. */
+    rectangles?: AnnotationRectangle[] | undefined;
+}
+
+/** A rectangular region on a page, in image pixels from the top-left corner. */
+export class AnnotationRectangle implements IAnnotationRectangle {
+    /** The horizontal offset in pixels of the left edge of the rectangle. */
+    x?: number;
+    /** The vertical offset in pixels of the top edge of the rectangle. */
+    y?: number;
+    /** The width of the rectangle in pixels. */
+    width?: number;
+    /** The height of the rectangle in pixels. */
+    height?: number;
+
+    
+    
+    constructor(data?: IAnnotationRectangle) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -11361,55 +13691,352 @@ export class AttributeCollectionResponse implements IAttributeCollectionResponse
 
     init(_data?: any) {
         if (_data) {
-            this.odataNextLink = _data["@odata.nextLink"];
-            this.odataCount = _data["@odata.count"];
-            if (Array.isArray(_data["value"])) {
-                this.value = [] as any;
-                for (let item of _data["value"])
-                    this.value!.push(Attribute.fromJS(item));
-            }
+            this.x = _data["x"];
+            this.y = _data["y"];
+            this.width = _data["width"];
+            this.height = _data["height"];
         }
     }
 
-    static fromJS(data: any): AttributeCollectionResponse {
+    static fromJS(data: any): AnnotationRectangle {
         data = typeof data === 'object' ? data : {};
-        let result = new AttributeCollectionResponse();
+        let result = new AnnotationRectangle();
         result.init(data);
         return result;
     }
 
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
-        data["@odata.nextLink"] = this.odataNextLink;
-        data["@odata.count"] = this.odataCount;
-        if (Array.isArray(this.value)) {
-            data["value"] = [];
-            for (let item of this.value)
-                data["value"].push(item.toJSON());
-        }
+        data["x"] = this.x;
+        data["y"] = this.y;
+        data["width"] = this.width;
+        data["height"] = this.height;
         return data;
     }
 }
 
-/** Response containing a collection of Attribute. */
-export interface IAttributeCollectionResponse {
-    /** A URL to retrieve the next page of the requested collection. */
-    odataNextLink?: string | undefined;
-    /** The total count of items within a collection. */
-    odataCount?: number | undefined;
-    value?: Attribute[] | undefined;
+/** A rectangular region on a page, in image pixels from the top-left corner. */
+export interface IAnnotationRectangle {
+    /** The horizontal offset in pixels of the left edge of the rectangle. */
+    x?: number;
+    /** The vertical offset in pixels of the top edge of the rectangle. */
+    y?: number;
+    /** The width of the rectangle in pixels. */
+    width?: number;
+    /** The height of the rectangle in pixels. */
+    height?: number;
 }
 
-/** Represents a trustee attribute. */
-export class Attribute implements IAttribute {
-    /** The attribute key. */
-    key?: string | undefined;
-    /** The attribute value. */
-    value?: string | undefined;
+/** Obscures one or more regions of a page. Redactions are overlays; the underlying content is preserved and is only hidden from users without the right to see through redactions. */
+export class RedactionAnnotation extends Annotation implements IRedactionAnnotation {
+    /** A boolean indicating whether the region is whited out (true) rather than blacked out (false). */
+    isWhiteout?: boolean;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the redaction. */
+    rectangles?: AnnotationRectangle[] | undefined;
 
     
     
-    constructor(data?: IAttribute) {
+    constructor(data?: IRedactionAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Redaction";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.isWhiteout = _data["isWhiteout"];
+            this.textStart = _data["textStart"];
+            this.textEnd = _data["textEnd"];
+            if (Array.isArray(_data["rectangles"])) {
+                this.rectangles = [] as any;
+                for (let item of _data["rectangles"])
+                    this.rectangles!.push(AnnotationRectangle.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): RedactionAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new RedactionAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["isWhiteout"] = this.isWhiteout;
+        data["textStart"] = this.textStart;
+        data["textEnd"] = this.textEnd;
+        if (Array.isArray(this.rectangles)) {
+            data["rectangles"] = [];
+            for (let item of this.rectangles)
+                data["rectangles"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** Obscures one or more regions of a page. Redactions are overlays; the underlying content is preserved and is only hidden from users without the right to see through redactions. */
+export interface IRedactionAnnotation extends IAnnotation {
+    /** A boolean indicating whether the region is whited out (true) rather than blacked out (false). */
+    isWhiteout?: boolean;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the redaction. */
+    rectangles?: AnnotationRectangle[] | undefined;
+}
+
+/** Strikes through one or more regions of a page. */
+export class StrikeoutAnnotation extends Annotation implements IStrikeoutAnnotation {
+    /** The strikeout color as an RGB hex string (for example, "#FF0000"); null if transparent. */
+    color?: string | undefined;
+    /** The reading direction of the struck-through text. */
+    direction?: TextDirection;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the strikeout. */
+    rectangles?: AnnotationRectangle[] | undefined;
+
+    
+    
+    constructor(data?: IStrikeoutAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Strikeout";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.color = _data["color"];
+            this.direction = _data["direction"];
+            this.textStart = _data["textStart"];
+            this.textEnd = _data["textEnd"];
+            if (Array.isArray(_data["rectangles"])) {
+                this.rectangles = [] as any;
+                for (let item of _data["rectangles"])
+                    this.rectangles!.push(AnnotationRectangle.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): StrikeoutAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new StrikeoutAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["color"] = this.color;
+        data["direction"] = this.direction;
+        data["textStart"] = this.textStart;
+        data["textEnd"] = this.textEnd;
+        if (Array.isArray(this.rectangles)) {
+            data["rectangles"] = [];
+            for (let item of this.rectangles)
+                data["rectangles"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** Strikes through one or more regions of a page. */
+export interface IStrikeoutAnnotation extends IAnnotation {
+    /** The strikeout color as an RGB hex string (for example, "#FF0000"); null if transparent. */
+    color?: string | undefined;
+    /** The reading direction of the struck-through text. */
+    direction?: TextDirection;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the strikeout. */
+    rectangles?: AnnotationRectangle[] | undefined;
+}
+
+/** The reading direction of annotation text. */
+export enum TextDirection {
+    LeftToRight = "LeftToRight",
+    TopToBottom = "TopToBottom",
+    RightToLeft = "RightToLeft",
+    BottomToTop = "BottomToTop",
+}
+
+/** Underlines one or more regions of a page. */
+export class UnderlineAnnotation extends Annotation implements IUnderlineAnnotation {
+    /** The underline color as an RGB hex string (for example, "#FF0000"); null if transparent. */
+    color?: string | undefined;
+    /** The reading direction of the underlined text. */
+    direction?: TextDirection;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the underline. */
+    rectangles?: AnnotationRectangle[] | undefined;
+
+    
+    
+    constructor(data?: IUnderlineAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Underline";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.color = _data["color"];
+            this.direction = _data["direction"];
+            this.textStart = _data["textStart"];
+            this.textEnd = _data["textEnd"];
+            if (Array.isArray(_data["rectangles"])) {
+                this.rectangles = [] as any;
+                for (let item of _data["rectangles"])
+                    this.rectangles!.push(AnnotationRectangle.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): UnderlineAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new UnderlineAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["color"] = this.color;
+        data["direction"] = this.direction;
+        data["textStart"] = this.textStart;
+        data["textEnd"] = this.textEnd;
+        if (Array.isArray(this.rectangles)) {
+            data["rectangles"] = [];
+            for (let item of this.rectangles)
+                data["rectangles"].push(item.toJSON());
+        }
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** Underlines one or more regions of a page. */
+export interface IUnderlineAnnotation extends IAnnotation {
+    /** The underline color as an RGB hex string (for example, "#FF0000"); null if transparent. */
+    color?: string | undefined;
+    /** The reading direction of the underlined text. */
+    direction?: TextDirection;
+    /** The start offset of the linked text span, or -1 when not linked to text. */
+    textStart?: number;
+    /** The end offset of the linked text span, or -1 when not linked to text. */
+    textEnd?: number;
+    /** The rectangular regions covered by the underline. */
+    rectangles?: AnnotationRectangle[] | undefined;
+}
+
+/** A sticky note placed on a page. */
+export class NoteAnnotation extends Annotation implements INoteAnnotation {
+    /** The top-left position of the note on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The background color of the note as an RGB hex string (for example, "#FFFF00"); null if transparent. */
+    color?: string | undefined;
+    /** The text content of the note. */
+    text?: string | undefined;
+    /** A boolean indicating whether the note keeps a revision history. */
+    keepHistory?: boolean;
+
+    
+    
+    constructor(data?: INoteAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Note";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.position = _data["position"] ? AnnotationPoint.fromJS(_data["position"]) : <any>undefined;
+            this.color = _data["color"];
+            this.text = _data["text"];
+            this.keepHistory = _data["keepHistory"];
+        }
+    }
+
+    static fromJS(data: any): NoteAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new NoteAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["position"] = this.position ? this.position.toJSON() : <any>undefined;
+        data["color"] = this.color;
+        data["text"] = this.text;
+        data["keepHistory"] = this.keepHistory;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A sticky note placed on a page. */
+export interface INoteAnnotation extends IAnnotation {
+    /** The top-left position of the note on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The background color of the note as an RGB hex string (for example, "#FFFF00"); null if transparent. */
+    color?: string | undefined;
+    /** The text content of the note. */
+    text?: string | undefined;
+    /** A boolean indicating whether the note keeps a revision history. */
+    keepHistory?: boolean;
+}
+
+/** A point on a page, in image pixels from the top-left corner. */
+export class AnnotationPoint implements IAnnotationPoint {
+    /** The horizontal offset in pixels from the left edge of the page. */
+    x?: number;
+    /** The vertical offset in pixels from the top edge of the page. */
+    y?: number;
+
+    
+    
+    constructor(data?: IAnnotationPoint) {
         if (data) {
             for (var property in data) {
                 if (data.hasOwnProperty(property))
@@ -11420,32 +14047,868 @@ export class Attribute implements IAttribute {
 
     init(_data?: any) {
         if (_data) {
-            this.key = _data["key"];
-            this.value = _data["value"];
+            this.x = _data["x"];
+            this.y = _data["y"];
         }
     }
 
-    static fromJS(data: any): Attribute {
+    static fromJS(data: any): AnnotationPoint {
         data = typeof data === 'object' ? data : {};
-        let result = new Attribute();
+        let result = new AnnotationPoint();
         result.init(data);
         return result;
     }
 
     toJSON(data?: any) {
         data = typeof data === 'object' ? data : {};
-        data["key"] = this.key;
-        data["value"] = this.value;
+        data["x"] = this.x;
+        data["y"] = this.y;
         return data;
     }
 }
 
-/** Represents a trustee attribute. */
-export interface IAttribute {
-    /** The attribute key. */
-    key?: string | undefined;
-    /** The attribute value. */
-    value?: string | undefined;
+/** A point on a page, in image pixels from the top-left corner. */
+export interface IAnnotationPoint {
+    /** The horizontal offset in pixels from the left edge of the page. */
+    x?: number;
+    /** The vertical offset in pixels from the top edge of the page. */
+    y?: number;
+}
+
+/** A file attached to a page. The attached file's bytes are retrieved through the attachment-content endpoint, not in the annotation response. */
+export class AttachmentAnnotation extends Annotation implements IAttachmentAnnotation {
+    /** The top-left position of the attachment icon on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The original file name of the attachment. */
+    fileName?: string | undefined;
+    /** The MIME type of the attached file. */
+    mimeType?: string | undefined;
+    /** The size of the attached file in bytes. */
+    attachmentLength?: number;
+
+    
+    
+    constructor(data?: IAttachmentAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Attachment";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.position = _data["position"] ? AnnotationPoint.fromJS(_data["position"]) : <any>undefined;
+            this.fileName = _data["fileName"];
+            this.mimeType = _data["mimeType"];
+            this.attachmentLength = _data["attachmentLength"];
+        }
+    }
+
+    static fromJS(data: any): AttachmentAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new AttachmentAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["position"] = this.position ? this.position.toJSON() : <any>undefined;
+        data["fileName"] = this.fileName;
+        data["mimeType"] = this.mimeType;
+        data["attachmentLength"] = this.attachmentLength;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A file attached to a page. The attached file's bytes are retrieved through the attachment-content endpoint, not in the annotation response. */
+export interface IAttachmentAnnotation extends IAnnotation {
+    /** The top-left position of the attachment icon on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The original file name of the attachment. */
+    fileName?: string | undefined;
+    /** The MIME type of the attached file. */
+    mimeType?: string | undefined;
+    /** The size of the attached file in bytes. */
+    attachmentLength?: number;
+}
+
+/** A bordered text box drawn on a page. */
+export class TextBoxAnnotation extends Annotation implements ITextBoxAnnotation {
+    /** The bounding rectangle of the text box. */
+    coordinates?: AnnotationRectangle | undefined;
+    /** The fill color as an RGB hex string; null if not filled. */
+    fillColor?: string | undefined;
+    /** The border color as an RGB hex string; null if transparent. */
+    borderColor?: string | undefined;
+    /** The border stroke style. */
+    borderStyle?: LineStyle;
+    /** The border thickness in pixels. */
+    borderThickness?: number;
+    /** The opacity of the text box as a percentage (0-100). */
+    opacity?: number;
+    /** The text displayed in the box. */
+    text?: string | undefined;
+    /** The font size of the text in points. */
+    textSize?: number;
+    /** The reading direction of the text. */
+    direction?: TextDirection;
+
+    
+    
+    constructor(data?: ITextBoxAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "TextBox";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.coordinates = _data["coordinates"] ? AnnotationRectangle.fromJS(_data["coordinates"]) : <any>undefined;
+            this.fillColor = _data["fillColor"];
+            this.borderColor = _data["borderColor"];
+            this.borderStyle = _data["borderStyle"];
+            this.borderThickness = _data["borderThickness"];
+            this.opacity = _data["opacity"];
+            this.text = _data["text"];
+            this.textSize = _data["textSize"];
+            this.direction = _data["direction"];
+        }
+    }
+
+    static fromJS(data: any): TextBoxAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new TextBoxAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["coordinates"] = this.coordinates ? this.coordinates.toJSON() : <any>undefined;
+        data["fillColor"] = this.fillColor;
+        data["borderColor"] = this.borderColor;
+        data["borderStyle"] = this.borderStyle;
+        data["borderThickness"] = this.borderThickness;
+        data["opacity"] = this.opacity;
+        data["text"] = this.text;
+        data["textSize"] = this.textSize;
+        data["direction"] = this.direction;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A bordered text box drawn on a page. */
+export interface ITextBoxAnnotation extends IAnnotation {
+    /** The bounding rectangle of the text box. */
+    coordinates?: AnnotationRectangle | undefined;
+    /** The fill color as an RGB hex string; null if not filled. */
+    fillColor?: string | undefined;
+    /** The border color as an RGB hex string; null if transparent. */
+    borderColor?: string | undefined;
+    /** The border stroke style. */
+    borderStyle?: LineStyle;
+    /** The border thickness in pixels. */
+    borderThickness?: number;
+    /** The opacity of the text box as a percentage (0-100). */
+    opacity?: number;
+    /** The text displayed in the box. */
+    text?: string | undefined;
+    /** The font size of the text in points. */
+    textSize?: number;
+    /** The reading direction of the text. */
+    direction?: TextDirection;
+}
+
+/** The stroke style of a line or border. */
+export enum LineStyle {
+    Solid = "Solid",
+    Dashed1 = "Dashed1",
+    Dashed2 = "Dashed2",
+    Dashed3 = "Dashed3",
+    Dashed4 = "Dashed4",
+    Dashed5 = "Dashed5",
+    Dashed6 = "Dashed6",
+    Cloud1 = "Cloud1",
+    Cloud2 = "Cloud2",
+}
+
+/** An image placed on a page. The image bytes are not included in the annotation response; they are uploaded and managed separately. */
+export class BitmapAnnotation extends Annotation implements IBitmapAnnotation {
+    /** The top-left position of the image on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The rendered size of the image in pixels. */
+    size?: AnnotationSize | undefined;
+    /** The clockwise rotation of the image in degrees (0-359). */
+    rotation?: number;
+    /** The opacity of the image as a percentage (0-100). */
+    opacity?: number;
+
+    
+    
+    constructor(data?: IBitmapAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Bitmap";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.position = _data["position"] ? AnnotationPoint.fromJS(_data["position"]) : <any>undefined;
+            this.size = _data["size"] ? AnnotationSize.fromJS(_data["size"]) : <any>undefined;
+            this.rotation = _data["rotation"];
+            this.opacity = _data["opacity"];
+        }
+    }
+
+    static fromJS(data: any): BitmapAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new BitmapAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["position"] = this.position ? this.position.toJSON() : <any>undefined;
+        data["size"] = this.size ? this.size.toJSON() : <any>undefined;
+        data["rotation"] = this.rotation;
+        data["opacity"] = this.opacity;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** An image placed on a page. The image bytes are not included in the annotation response; they are uploaded and managed separately. */
+export interface IBitmapAnnotation extends IAnnotation {
+    /** The top-left position of the image on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The rendered size of the image in pixels. */
+    size?: AnnotationSize | undefined;
+    /** The clockwise rotation of the image in degrees (0-359). */
+    rotation?: number;
+    /** The opacity of the image as a percentage (0-100). */
+    opacity?: number;
+}
+
+/** A size in image pixels. */
+export class AnnotationSize implements IAnnotationSize {
+    /** The width in pixels. */
+    width?: number;
+    /** The height in pixels. */
+    height?: number;
+
+    
+    
+    constructor(data?: IAnnotationSize) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.width = _data["width"];
+            this.height = _data["height"];
+        }
+    }
+
+    static fromJS(data: any): AnnotationSize {
+        data = typeof data === 'object' ? data : {};
+        let result = new AnnotationSize();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["width"] = this.width;
+        data["height"] = this.height;
+        return data;
+    }
+}
+
+/** A size in image pixels. */
+export interface IAnnotationSize {
+    /** The width in pixels. */
+    width?: number;
+    /** The height in pixels. */
+    height?: number;
+}
+
+/** A straight line or arrow drawn on a page. */
+export class LineAnnotation extends Annotation implements ILineAnnotation {
+    /** The start point of the line. */
+    beginPosition?: AnnotationPoint | undefined;
+    /** The end point of the line. */
+    endPosition?: AnnotationPoint | undefined;
+    /** The cap style at the start of the line. */
+    beginStyle?: LineEndingStyle;
+    /** The cap style at the end of the line. */
+    endStyle?: LineEndingStyle;
+    /** The line stroke style. */
+    lineStyle?: LineStyle;
+    /** The line color as an RGB hex string; null if transparent. */
+    color?: string | undefined;
+    /** The end-cap color as an RGB hex string; null if transparent. */
+    endColor?: string | undefined;
+    /** The line thickness in pixels. */
+    thickness?: number;
+    /** The opacity of the line as a percentage (0-100). */
+    opacity?: number;
+
+    
+    
+    constructor(data?: ILineAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Line";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.beginPosition = _data["beginPosition"] ? AnnotationPoint.fromJS(_data["beginPosition"]) : <any>undefined;
+            this.endPosition = _data["endPosition"] ? AnnotationPoint.fromJS(_data["endPosition"]) : <any>undefined;
+            this.beginStyle = _data["beginStyle"];
+            this.endStyle = _data["endStyle"];
+            this.lineStyle = _data["lineStyle"];
+            this.color = _data["color"];
+            this.endColor = _data["endColor"];
+            this.thickness = _data["thickness"];
+            this.opacity = _data["opacity"];
+        }
+    }
+
+    static fromJS(data: any): LineAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new LineAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["beginPosition"] = this.beginPosition ? this.beginPosition.toJSON() : <any>undefined;
+        data["endPosition"] = this.endPosition ? this.endPosition.toJSON() : <any>undefined;
+        data["beginStyle"] = this.beginStyle;
+        data["endStyle"] = this.endStyle;
+        data["lineStyle"] = this.lineStyle;
+        data["color"] = this.color;
+        data["endColor"] = this.endColor;
+        data["thickness"] = this.thickness;
+        data["opacity"] = this.opacity;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A straight line or arrow drawn on a page. */
+export interface ILineAnnotation extends IAnnotation {
+    /** The start point of the line. */
+    beginPosition?: AnnotationPoint | undefined;
+    /** The end point of the line. */
+    endPosition?: AnnotationPoint | undefined;
+    /** The cap style at the start of the line. */
+    beginStyle?: LineEndingStyle;
+    /** The cap style at the end of the line. */
+    endStyle?: LineEndingStyle;
+    /** The line stroke style. */
+    lineStyle?: LineStyle;
+    /** The line color as an RGB hex string; null if transparent. */
+    color?: string | undefined;
+    /** The end-cap color as an RGB hex string; null if transparent. */
+    endColor?: string | undefined;
+    /** The line thickness in pixels. */
+    thickness?: number;
+    /** The opacity of the line as a percentage (0-100). */
+    opacity?: number;
+}
+
+/** The cap style at the end of a line. */
+export enum LineEndingStyle {
+    None = "None",
+    Open = "Open",
+    Closed = "Closed",
+    OpenReversed = "OpenReversed",
+    ClosedReversed = "ClosedReversed",
+    Butt = "Butt",
+    Diamond = "Diamond",
+    Round = "Round",
+    Square = "Square",
+    Slash = "Slash",
+}
+
+/** A rectangle, rounded rectangle, or ellipse drawn on a page. */
+export class RectangleAnnotation extends Annotation implements IRectangleAnnotation {
+    /** The bounding rectangle of the shape. */
+    coordinates?: AnnotationRectangle | undefined;
+    /** The fill color as an RGB hex string (for example, "#FF0000"); null if not filled. */
+    fillColor?: string | undefined;
+    /** The shape drawn within the bounding rectangle. */
+    boxStyle?: BoxStyle;
+    /** The border stroke style. */
+    borderStyle?: LineStyle;
+    /** The border color as an RGB hex string; null if transparent. */
+    borderColor?: string | undefined;
+    /** The border thickness in pixels. */
+    borderThickness?: number;
+    /** The opacity of the shape as a percentage (0-100). */
+    opacity?: number;
+
+    
+    
+    constructor(data?: IRectangleAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Rectangle";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.coordinates = _data["coordinates"] ? AnnotationRectangle.fromJS(_data["coordinates"]) : <any>undefined;
+            this.fillColor = _data["fillColor"];
+            this.boxStyle = _data["boxStyle"];
+            this.borderStyle = _data["borderStyle"];
+            this.borderColor = _data["borderColor"];
+            this.borderThickness = _data["borderThickness"];
+            this.opacity = _data["opacity"];
+        }
+    }
+
+    static fromJS(data: any): RectangleAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new RectangleAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["coordinates"] = this.coordinates ? this.coordinates.toJSON() : <any>undefined;
+        data["fillColor"] = this.fillColor;
+        data["boxStyle"] = this.boxStyle;
+        data["borderStyle"] = this.borderStyle;
+        data["borderColor"] = this.borderColor;
+        data["borderThickness"] = this.borderThickness;
+        data["opacity"] = this.opacity;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A rectangle, rounded rectangle, or ellipse drawn on a page. */
+export interface IRectangleAnnotation extends IAnnotation {
+    /** The bounding rectangle of the shape. */
+    coordinates?: AnnotationRectangle | undefined;
+    /** The fill color as an RGB hex string (for example, "#FF0000"); null if not filled. */
+    fillColor?: string | undefined;
+    /** The shape drawn within the bounding rectangle. */
+    boxStyle?: BoxStyle;
+    /** The border stroke style. */
+    borderStyle?: LineStyle;
+    /** The border color as an RGB hex string; null if transparent. */
+    borderColor?: string | undefined;
+    /** The border thickness in pixels. */
+    borderThickness?: number;
+    /** The opacity of the shape as a percentage (0-100). */
+    opacity?: number;
+}
+
+/** The shape of a rectangle annotation. */
+export enum BoxStyle {
+    Rectangle = "Rectangle",
+    Ellipse = "Ellipse",
+    RoundedRectangle = "RoundedRectangle",
+}
+
+/** A closed multi-point polygon drawn on a page. */
+export class PolylineAnnotation extends Annotation implements IPolylineAnnotation {
+    /** The ordered vertices of the polygon. */
+    points?: AnnotationPoint[] | undefined;
+    /** The border stroke style. */
+    lineStyle?: LineStyle;
+    /** The fill color as an RGB hex string; null if not filled. */
+    fillColor?: string | undefined;
+    /** Whether the polygon is filled. */
+    fillStyle?: FillStyle;
+    /** The border color as an RGB hex string; null if transparent. */
+    color?: string | undefined;
+    /** The border thickness in pixels. */
+    thickness?: number;
+    /** The opacity of the polygon as a percentage (0-100). */
+    opacity?: number;
+
+    
+    
+    constructor(data?: IPolylineAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Polyline";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["points"])) {
+                this.points = [] as any;
+                for (let item of _data["points"])
+                    this.points!.push(AnnotationPoint.fromJS(item));
+            }
+            this.lineStyle = _data["lineStyle"];
+            this.fillColor = _data["fillColor"];
+            this.fillStyle = _data["fillStyle"];
+            this.color = _data["color"];
+            this.thickness = _data["thickness"];
+            this.opacity = _data["opacity"];
+        }
+    }
+
+    static fromJS(data: any): PolylineAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new PolylineAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.points)) {
+            data["points"] = [];
+            for (let item of this.points)
+                data["points"].push(item.toJSON());
+        }
+        data["lineStyle"] = this.lineStyle;
+        data["fillColor"] = this.fillColor;
+        data["fillStyle"] = this.fillStyle;
+        data["color"] = this.color;
+        data["thickness"] = this.thickness;
+        data["opacity"] = this.opacity;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A closed multi-point polygon drawn on a page. */
+export interface IPolylineAnnotation extends IAnnotation {
+    /** The ordered vertices of the polygon. */
+    points?: AnnotationPoint[] | undefined;
+    /** The border stroke style. */
+    lineStyle?: LineStyle;
+    /** The fill color as an RGB hex string; null if not filled. */
+    fillColor?: string | undefined;
+    /** Whether the polygon is filled. */
+    fillStyle?: FillStyle;
+    /** The border color as an RGB hex string; null if transparent. */
+    color?: string | undefined;
+    /** The border thickness in pixels. */
+    thickness?: number;
+    /** The opacity of the polygon as a percentage (0-100). */
+    opacity?: number;
+}
+
+/** Whether a closed shape is filled. */
+export enum FillStyle {
+    None = "None",
+    Solid = "Solid",
+}
+
+/** A text box with a pointer leading to a focus point on the page. */
+export class CalloutAnnotation extends Annotation implements ICalloutAnnotation {
+    /** The bounding rectangle of the callout's text box. */
+    boxCoordinates?: AnnotationRectangle | undefined;
+    /** The point the callout pointer leads to. */
+    focusPosition?: AnnotationPoint | undefined;
+    /** The fill color as an RGB hex string; null if not filled. */
+    fillColor?: string | undefined;
+    /** The border and pointer color as an RGB hex string; null if transparent. */
+    borderColor?: string | undefined;
+    /** The border stroke style. */
+    borderStyle?: LineStyle;
+    /** The border thickness in pixels. */
+    borderThickness?: number;
+    /** The cap style at the focus end of the pointer. */
+    focusStyle?: LineEndingStyle;
+    /** The opacity of the callout as a percentage (0-100). */
+    opacity?: number;
+    /** The font size of the text in points. */
+    textSize?: number;
+    /** The text displayed in the callout. */
+    text?: string | undefined;
+    /** The reading direction of the text. */
+    direction?: TextDirection;
+
+    
+    
+    constructor(data?: ICalloutAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Callout";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.boxCoordinates = _data["boxCoordinates"] ? AnnotationRectangle.fromJS(_data["boxCoordinates"]) : <any>undefined;
+            this.focusPosition = _data["focusPosition"] ? AnnotationPoint.fromJS(_data["focusPosition"]) : <any>undefined;
+            this.fillColor = _data["fillColor"];
+            this.borderColor = _data["borderColor"];
+            this.borderStyle = _data["borderStyle"];
+            this.borderThickness = _data["borderThickness"];
+            this.focusStyle = _data["focusStyle"];
+            this.opacity = _data["opacity"];
+            this.textSize = _data["textSize"];
+            this.text = _data["text"];
+            this.direction = _data["direction"];
+        }
+    }
+
+    static fromJS(data: any): CalloutAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new CalloutAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["boxCoordinates"] = this.boxCoordinates ? this.boxCoordinates.toJSON() : <any>undefined;
+        data["focusPosition"] = this.focusPosition ? this.focusPosition.toJSON() : <any>undefined;
+        data["fillColor"] = this.fillColor;
+        data["borderColor"] = this.borderColor;
+        data["borderStyle"] = this.borderStyle;
+        data["borderThickness"] = this.borderThickness;
+        data["focusStyle"] = this.focusStyle;
+        data["opacity"] = this.opacity;
+        data["textSize"] = this.textSize;
+        data["text"] = this.text;
+        data["direction"] = this.direction;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A text box with a pointer leading to a focus point on the page. */
+export interface ICalloutAnnotation extends IAnnotation {
+    /** The bounding rectangle of the callout's text box. */
+    boxCoordinates?: AnnotationRectangle | undefined;
+    /** The point the callout pointer leads to. */
+    focusPosition?: AnnotationPoint | undefined;
+    /** The fill color as an RGB hex string; null if not filled. */
+    fillColor?: string | undefined;
+    /** The border and pointer color as an RGB hex string; null if transparent. */
+    borderColor?: string | undefined;
+    /** The border stroke style. */
+    borderStyle?: LineStyle;
+    /** The border thickness in pixels. */
+    borderThickness?: number;
+    /** The cap style at the focus end of the pointer. */
+    focusStyle?: LineEndingStyle;
+    /** The opacity of the callout as a percentage (0-100). */
+    opacity?: number;
+    /** The font size of the text in points. */
+    textSize?: number;
+    /** The text displayed in the callout. */
+    text?: string | undefined;
+    /** The reading direction of the text. */
+    direction?: TextDirection;
+}
+
+/** A placement of a catalog stamp on a page. The stamp image itself is defined by the catalog entry referenced by StampId. */
+export class StampAnnotation extends Annotation implements IStampAnnotation {
+    /** The ID of the catalog stamp placed; 0 when the stamp carries its own inline bitmap. */
+    stampId?: number;
+    /** The rectangle the stamp is drawn into. */
+    coordinates?: AnnotationRectangle | undefined;
+    /** The top-left position of the stamp on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The render color of the stamp as an RGB hex string (for example, "#000000"); null if transparent. */
+    color?: string | undefined;
+    /** The clockwise rotation of the stamp in degrees (0-359). */
+    rotation?: number;
+    /** The opacity of the stamp as a percentage (0-100). */
+    opacity?: number;
+
+    
+    
+    constructor(data?: IStampAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "Stamp";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            this.stampId = _data["stampId"];
+            this.coordinates = _data["coordinates"] ? AnnotationRectangle.fromJS(_data["coordinates"]) : <any>undefined;
+            this.position = _data["position"] ? AnnotationPoint.fromJS(_data["position"]) : <any>undefined;
+            this.color = _data["color"];
+            this.rotation = _data["rotation"];
+            this.opacity = _data["opacity"];
+        }
+    }
+
+    static fromJS(data: any): StampAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new StampAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["stampId"] = this.stampId;
+        data["coordinates"] = this.coordinates ? this.coordinates.toJSON() : <any>undefined;
+        data["position"] = this.position ? this.position.toJSON() : <any>undefined;
+        data["color"] = this.color;
+        data["rotation"] = this.rotation;
+        data["opacity"] = this.opacity;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A placement of a catalog stamp on a page. The stamp image itself is defined by the catalog entry referenced by StampId. */
+export interface IStampAnnotation extends IAnnotation {
+    /** The ID of the catalog stamp placed; 0 when the stamp carries its own inline bitmap. */
+    stampId?: number;
+    /** The rectangle the stamp is drawn into. */
+    coordinates?: AnnotationRectangle | undefined;
+    /** The top-left position of the stamp on the page. */
+    position?: AnnotationPoint | undefined;
+    /** The render color of the stamp as an RGB hex string (for example, "#000000"); null if transparent. */
+    color?: string | undefined;
+    /** The clockwise rotation of the stamp in degrees (0-359). */
+    rotation?: number;
+    /** The opacity of the stamp as a percentage (0-100). */
+    opacity?: number;
+}
+
+/** A freehand-drawn multi-point line on a page. */
+export class FreeHandAnnotation extends Annotation implements IFreeHandAnnotation {
+    /** The ordered points of the freehand stroke. */
+    points?: AnnotationPoint[] | undefined;
+    /** The stroke style. */
+    lineStyle?: LineStyle;
+    /** The stroke color as an RGB hex string; null if transparent. */
+    color?: string | undefined;
+    /** The stroke thickness in pixels. */
+    thickness?: number;
+    /** The opacity of the stroke as a percentage (0-100). */
+    opacity?: number;
+
+    
+    
+    constructor(data?: IFreeHandAnnotation) {
+        super(data);
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+        this._discriminator = "FreeHand";
+    }
+
+    init(_data?: any) {
+        super.init(_data);
+        if (_data) {
+            if (Array.isArray(_data["points"])) {
+                this.points = [] as any;
+                for (let item of _data["points"])
+                    this.points!.push(AnnotationPoint.fromJS(item));
+            }
+            this.lineStyle = _data["lineStyle"];
+            this.color = _data["color"];
+            this.thickness = _data["thickness"];
+            this.opacity = _data["opacity"];
+        }
+    }
+
+    static fromJS(data: any): FreeHandAnnotation {
+        data = typeof data === 'object' ? data : {};
+        let result = new FreeHandAnnotation();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        if (Array.isArray(this.points)) {
+            data["points"] = [];
+            for (let item of this.points)
+                data["points"].push(item.toJSON());
+        }
+        data["lineStyle"] = this.lineStyle;
+        data["color"] = this.color;
+        data["thickness"] = this.thickness;
+        data["opacity"] = this.opacity;
+        super.toJSON(data);
+        return data;
+    }
+}
+
+/** A freehand-drawn multi-point line on a page. */
+export interface IFreeHandAnnotation extends IAnnotation {
+    /** The ordered points of the freehand stroke. */
+    points?: AnnotationPoint[] | undefined;
+    /** The stroke style. */
+    lineStyle?: LineStyle;
+    /** The stroke color as an RGB hex string; null if transparent. */
+    color?: string | undefined;
+    /** The stroke thickness in pixels. */
+    thickness?: number;
+    /** The opacity of the stroke as a percentage (0-100). */
+    opacity?: number;
 }
 
 /** A machine-readable format for specifying errors in HTTP API responses, per RFC 9457 (https://www.rfc-editor.org/rfc/rfc9457). Supersedes RFC 7807. */
@@ -11558,12 +15021,213 @@ export interface IProblemDetails {
     [key: string]: any;
 }
 
+/** A repository-defined reason that can be associated with a redaction annotation. */
+export class AnnotationReason implements IAnnotationReason {
+    /** The ID of the annotation reason. */
+    id?: number;
+    /** The display text of the annotation reason. */
+    text?: string | undefined;
+
+    
+    
+    constructor(data?: IAnnotationReason) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.text = _data["text"];
+        }
+    }
+
+    static fromJS(data: any): AnnotationReason {
+        data = typeof data === 'object' ? data : {};
+        let result = new AnnotationReason();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["text"] = this.text;
+        return data;
+    }
+}
+
+/** A repository-defined reason that can be associated with a redaction annotation. */
+export interface IAnnotationReason {
+    /** The ID of the annotation reason. */
+    id?: number;
+    /** The display text of the annotation reason. */
+    text?: string | undefined;
+}
+
+/** Request body for creating or updating an annotation (redaction) reason. */
+export class AnnotationReasonRequest implements IAnnotationReasonRequest {
+    /** The display text of the annotation reason. */
+    text?: string | undefined;
+
+    
+    
+    constructor(data?: IAnnotationReasonRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.text = _data["text"];
+        }
+    }
+
+    static fromJS(data: any): AnnotationReasonRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new AnnotationReasonRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["text"] = this.text;
+        return data;
+    }
+}
+
+/** Request body for creating or updating an annotation (redaction) reason. */
+export interface IAnnotationReasonRequest {
+    /** The display text of the annotation reason. */
+    text?: string | undefined;
+}
+
+/** Response containing a collection of Attribute. */
+export class AttributeCollectionResponse implements IAttributeCollectionResponse {
+    /** A URL to retrieve the next page of the requested collection. */
+    odataNextLink?: string | undefined;
+    /** The total count of items within a collection. */
+    odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
+    value?: Attribute[] | undefined;
+
+    
+    
+    constructor(data?: IAttributeCollectionResponse) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.odataNextLink = _data["@odata.nextLink"];
+            this.odataCount = _data["@odata.count"];
+            if (Array.isArray(_data["value"])) {
+                this.value = [] as any;
+                for (let item of _data["value"])
+                    this.value!.push(Attribute.fromJS(item));
+            }
+        }
+    }
+
+    static fromJS(data: any): AttributeCollectionResponse {
+        data = typeof data === 'object' ? data : {};
+        let result = new AttributeCollectionResponse();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["@odata.nextLink"] = this.odataNextLink;
+        data["@odata.count"] = this.odataCount;
+        if (Array.isArray(this.value)) {
+            data["value"] = [];
+            for (let item of this.value)
+                data["value"].push(item.toJSON());
+        }
+        return data;
+    }
+}
+
+/** Response containing a collection of Attribute. */
+export interface IAttributeCollectionResponse {
+    /** A URL to retrieve the next page of the requested collection. */
+    odataNextLink?: string | undefined;
+    /** The total count of items within a collection. */
+    odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
+    value?: Attribute[] | undefined;
+}
+
+/** Represents a trustee attribute. */
+export class Attribute implements IAttribute {
+    /** The attribute key. */
+    key?: string | undefined;
+    /** The attribute value. */
+    value?: string | undefined;
+
+    
+    
+    constructor(data?: IAttribute) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.key = _data["key"];
+            this.value = _data["value"];
+        }
+    }
+
+    static fromJS(data: any): Attribute {
+        data = typeof data === 'object' ? data : {};
+        let result = new Attribute();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["key"] = this.key;
+        data["value"] = this.value;
+        return data;
+    }
+}
+
+/** Represents a trustee attribute. */
+export interface IAttribute {
+    /** The attribute key. */
+    key?: string | undefined;
+    /** The attribute value. */
+    value?: string | undefined;
+}
+
 /** Response containing a collection of AuditReason. */
 export class AuditReasonCollectionResponse implements IAuditReasonCollectionResponse {
     /** A URL to retrieve the next page of the requested collection. */
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: AuditReason[] | undefined;
 
     
@@ -11615,6 +15279,7 @@ export interface IAuditReasonCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: AuditReason[] | undefined;
 }
 
@@ -11879,6 +15544,7 @@ export class FieldDefinitionCollectionResponse implements IFieldDefinitionCollec
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
 
     
@@ -11930,6 +15596,7 @@ export interface IFieldDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: FieldDefinition[] | undefined;
 }
 
@@ -12852,6 +16519,7 @@ export class LinkDefinitionCollectionResponse implements ILinkDefinitionCollecti
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: LinkDefinition[] | undefined;
 
     
@@ -12903,6 +16571,7 @@ export interface ILinkDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: LinkDefinition[] | undefined;
 }
 
@@ -14696,6 +18365,7 @@ Does not affect pages generated from `file` — use `pdfOptions.generateText` fo
 
 /** Response containing a link to download the exported entry. */
 export class ExportEntryResponse implements IExportEntryResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: string | undefined;
 
     
@@ -14731,6 +18401,7 @@ export class ExportEntryResponse implements IExportEntryResponse {
 
 /** Response containing a link to download the exported entry. */
 export interface IExportEntryResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: string | undefined;
 }
 
@@ -14914,6 +18585,7 @@ export class EntryCollectionResponse implements IEntryCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Entry[] | undefined;
 
     
@@ -14965,6 +18637,7 @@ export interface IEntryCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Entry[] | undefined;
 }
 
@@ -14974,6 +18647,7 @@ export class FieldCollectionResponse implements IFieldCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Field[] | undefined;
 
     
@@ -15025,6 +18699,7 @@ export interface IFieldCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Field[] | undefined;
 }
 
@@ -15084,6 +18759,7 @@ export class TagCollectionResponse implements ITagCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Tag[] | undefined;
 
     
@@ -15135,6 +18811,7 @@ export interface ITagCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Tag[] | undefined;
 }
 
@@ -15338,6 +19015,7 @@ export class LinkCollectionResponse implements ILinkCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Link[] | undefined;
 
     
@@ -15389,6 +19067,7 @@ export interface ILinkCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: Link[] | undefined;
 }
 
@@ -16098,6 +19777,7 @@ export class PageInfoCollectionResponse implements IPageInfoCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: PageInfoResponse[] | undefined;
 
     
@@ -16149,6 +19829,7 @@ export interface IPageInfoCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: PageInfoResponse[] | undefined;
 }
 
@@ -16492,8 +20173,8 @@ Account renames change this value over time — do not use for stable identity c
 export class LockDocumentRequest implements ILockDocumentRequest {
     /** An optional comment for the persistent lock. */
     comment?: string | undefined;
-    /** The lock extent. Defaults to All when omitted. */
-    extent?: LockExtent | undefined;
+    /** The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted. */
+    extent?: string | undefined;
 
     
     
@@ -16532,16 +20213,8 @@ export class LockDocumentRequest implements ILockDocumentRequest {
 export interface ILockDocumentRequest {
     /** An optional comment for the persistent lock. */
     comment?: string | undefined;
-    /** The lock extent. Defaults to All when omitted. */
-    extent?: LockExtent | undefined;
-}
-
-/** The portion of a document that a persistent lock covers. */
-export enum LockExtent {
-    Page = "Page",
-    Edoc = "Edoc",
-    Metadata = "Metadata",
-    All = "All",
+    /** The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted. */
+    extent?: string | undefined;
 }
 
 /** Request body for checking out a document. */
@@ -16642,6 +20315,7 @@ export interface ICheckInDocumentRequest {
 
 /** Response containing a collection of Repository. */
 export class RepositoryCollectionResponse implements IRepositoryCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: Repository[] | undefined;
 
     
@@ -16685,6 +20359,7 @@ export class RepositoryCollectionResponse implements IRepositoryCollectionRespon
 
 /** Response containing a collection of Repository. */
 export interface IRepositoryCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: Repository[] | undefined;
 }
 
@@ -16808,6 +20483,7 @@ export class SearchContextHitCollectionResponse implements ISearchContextHitColl
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: SearchContextHit[] | undefined;
 
     
@@ -16859,6 +20535,7 @@ export interface ISearchContextHitCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: SearchContextHit[] | undefined;
 }
 
@@ -17050,12 +20727,146 @@ export interface ISearchEntryRequest {
     searchCommand: string;
 }
 
+/** A stamp in the repository stamp catalog. The stamp image is retrieved separately as a PNG. */
+export class Stamp implements IStamp {
+    /** The ID of the stamp. */
+    id?: number;
+    /** The display name of the stamp. */
+    name?: string | undefined;
+    /** A boolean indicating whether the stamp is public (shared) rather than personal. */
+    isPublic?: boolean;
+    /** The security identifier (SID) of the stamp's owner. */
+    owner?: string | undefined;
+    /** Optional application-defined custom data stored with the stamp. */
+    customData?: string | undefined;
+    /** The width of the stamp image in pixels. */
+    imageWidth?: number;
+    /** The height of the stamp image in pixels. */
+    imageHeight?: number;
+
+    
+    
+    constructor(data?: IStamp) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.id = _data["id"];
+            this.name = _data["name"];
+            this.isPublic = _data["isPublic"];
+            this.owner = _data["owner"];
+            this.customData = _data["customData"];
+            this.imageWidth = _data["imageWidth"];
+            this.imageHeight = _data["imageHeight"];
+        }
+    }
+
+    static fromJS(data: any): Stamp {
+        data = typeof data === 'object' ? data : {};
+        let result = new Stamp();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["id"] = this.id;
+        data["name"] = this.name;
+        data["isPublic"] = this.isPublic;
+        data["owner"] = this.owner;
+        data["customData"] = this.customData;
+        data["imageWidth"] = this.imageWidth;
+        data["imageHeight"] = this.imageHeight;
+        return data;
+    }
+}
+
+/** A stamp in the repository stamp catalog. The stamp image is retrieved separately as a PNG. */
+export interface IStamp {
+    /** The ID of the stamp. */
+    id?: number;
+    /** The display name of the stamp. */
+    name?: string | undefined;
+    /** A boolean indicating whether the stamp is public (shared) rather than personal. */
+    isPublic?: boolean;
+    /** The security identifier (SID) of the stamp's owner. */
+    owner?: string | undefined;
+    /** Optional application-defined custom data stored with the stamp. */
+    customData?: string | undefined;
+    /** The width of the stamp image in pixels. */
+    imageWidth?: number;
+    /** The height of the stamp image in pixels. */
+    imageHeight?: number;
+}
+
+/** Which stamps to list. */
+export enum StampScope {
+    Public = 0,
+    Personal = 1,
+    All = 2,
+}
+
+/** Request body for updating a stamp's metadata. The stamp image cannot be changed after creation. */
+export class UpdateStampRequest implements IUpdateStampRequest {
+    /** The new display name of the stamp. Omit to leave unchanged. */
+    name?: string | undefined;
+    /** New custom data for the stamp. Omit to leave unchanged. */
+    customData?: string | undefined;
+
+    
+    
+    constructor(data?: IUpdateStampRequest) {
+        if (data) {
+            for (var property in data) {
+                if (data.hasOwnProperty(property))
+                    (<any>this)[property] = (<any>data)[property];
+            }
+        }
+    }
+
+    init(_data?: any) {
+        if (_data) {
+            this.name = _data["name"];
+            this.customData = _data["customData"];
+        }
+    }
+
+    static fromJS(data: any): UpdateStampRequest {
+        data = typeof data === 'object' ? data : {};
+        let result = new UpdateStampRequest();
+        result.init(data);
+        return result;
+    }
+
+    toJSON(data?: any) {
+        data = typeof data === 'object' ? data : {};
+        data["name"] = this.name;
+        data["customData"] = this.customData;
+        return data;
+    }
+}
+
+/** Request body for updating a stamp's metadata. The stamp image cannot be changed after creation. */
+export interface IUpdateStampRequest {
+    /** The new display name of the stamp. Omit to leave unchanged. */
+    name?: string | undefined;
+    /** New custom data for the stamp. Omit to leave unchanged. */
+    customData?: string | undefined;
+}
+
 /** Response containing a collection of TagDefinition. */
 export class TagDefinitionCollectionResponse implements ITagDefinitionCollectionResponse {
     /** A URL to retrieve the next page of the requested collection. */
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TagDefinition[] | undefined;
 
     
@@ -17107,6 +20918,7 @@ export interface ITagDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TagDefinition[] | undefined;
 }
 
@@ -17184,6 +20996,7 @@ export interface ITagDefinition {
 
 /** Response containing a collection of TaskProgress. */
 export class TaskCollectionResponse implements ITaskCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: TaskProgress[] | undefined;
 
     
@@ -17227,6 +21040,7 @@ export class TaskCollectionResponse implements ITaskCollectionResponse {
 
 /** Response containing a collection of TaskProgress. */
 export interface ITaskCollectionResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: TaskProgress[] | undefined;
 }
 
@@ -17390,6 +21204,7 @@ export interface ITaskResult {
 
 /** Response containing a collection of CancelTaskResult. */
 export class CancelTasksResponse implements ICancelTasksResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: CancelTaskResult[] | undefined;
 
     
@@ -17433,6 +21248,7 @@ export class CancelTasksResponse implements ICancelTasksResponse {
 
 /** Response containing a collection of CancelTaskResult. */
 export interface ICancelTasksResponse {
+    /** Gets or sets the OData response content in the "value". */
     value?: CancelTaskResult[] | undefined;
 }
 
@@ -17496,6 +21312,7 @@ export class TemplateDefinitionCollectionResponse implements ITemplateDefinition
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
 
     
@@ -17547,6 +21364,7 @@ export interface ITemplateDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateDefinition[] | undefined;
 }
 
@@ -17556,6 +21374,7 @@ export class TemplateFieldDefinitionCollectionResponse implements ITemplateField
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateFieldDefinition[] | undefined;
 
     
@@ -17607,6 +21426,7 @@ export interface ITemplateFieldDefinitionCollectionResponse {
     odataNextLink?: string | undefined;
     /** The total count of items within a collection. */
     odataCount?: number | undefined;
+    /** Gets or sets the OData response content in the "value". */
     value?: TemplateFieldDefinition[] | undefined;
 }
 

--- a/packages/lf-repository-api-client-v2/test/Entries/CheckInCheckOut.test.ts
+++ b/packages/lf-repository-api-client-v2/test/Entries/CheckInCheckOut.test.ts
@@ -31,31 +31,37 @@ describe.skipIf(SKIP_UNDER_JSDOM)('Check In Check Out Integration Tests', () => 
   }
 
   afterEach(async () => {
-    if (createdEntryId !== 0) {
-      try {
-        await _RepositoryApiClient.entriesClient.undoCheckOut({
-          repositoryId,
-          entryId: createdEntryId,
-        });
-      } catch {
-        // Ignore if not checked out
-      }
-      try {
-        await _RepositoryApiClient.entriesClient.unlockDocument({
-          repositoryId,
-          entryId: createdEntryId,
-        });
-      } catch {
-        // Ignore if not locked
-      }
-      const request = new StartDeleteEntryRequest();
-      await _RepositoryApiClient.entriesClient.startDeleteEntry({
+    if (createdEntryId === 0) return;
+    try {
+      // Tests release their own lock/checkout on success, so only undo/unlock when the document is
+      // still locked (e.g. a test failed before releasing). This skips two slow error-path round-trips
+      // per test on the happy path instead of leaning on the raised hookTimeout.
+      const lockInfo = await _RepositoryApiClient.entriesClient.getDocumentLockInfo({
         repositoryId,
         entryId: createdEntryId,
-        request,
       });
-      createdEntryId = 0;
+      if (lockInfo.isActive) {
+        try {
+          await _RepositoryApiClient.entriesClient.undoCheckOut({ repositoryId, entryId: createdEntryId });
+        } catch {
+          // Ignore if not checked out
+        }
+        try {
+          await _RepositoryApiClient.entriesClient.unlockDocument({ repositoryId, entryId: createdEntryId });
+        } catch {
+          // Ignore if not locked
+        }
+      }
+    } catch {
+      // Ignore lock-info probe failures — fall through to delete.
     }
+    const request = new StartDeleteEntryRequest();
+    await _RepositoryApiClient.entriesClient.startDeleteEntry({
+      repositoryId,
+      entryId: createdEntryId,
+      request,
+    });
+    createdEntryId = 0;
   });
 
   test('PutUnderVersionControl then CheckOut then CheckIn', async () => {


### PR DESCRIPTION
Regenerates the V2 JS client against the combined Annotations & Stamps server surface (server PR Laserfiche/site-api-repository!173492, WI #674508).

## Changes
- Re-regen `lf-repository-api-client-v2` (`swagger.json` + `index.ts`) against the final annotations/stamps surface; the stale `GetStampImage` `scope` query param is dropped.
- Add `generate-client/swagger-override.json` carrying the polymorphic `Annotation` discriminator override so the generated client deserializes annotation subtypes correctly.
- Production server URL restored in `swagger.json` `servers[]` and `index.ts` defaults (localhost-regen trap).
- test(v2): trim `CheckInCheckOut` teardown to only undo/unlock when still locked, cutting two slow error-path round-trips per test.

## Notes
- Regen-only: no `package.json` version bump and no publish — version bump + publish ship in a separate, manually-approved release PR after the server side merges.
- No new annotation/stamp integration tests are added here (none exist yet for JS); the only test change is the CICO teardown optimization on an existing endpoint.