### PR TITLE
Drop npm@latest forced upgrade before pnpm publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Install pnpm
         run: npm install pnpm@latest-9 -g
 
@@ -124,9 +121,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install pnpm
         run: npm install pnpm@latest-9 -g
@@ -267,9 +261,6 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Install pnpm
         run: npm install pnpm@latest-9 -g
 
@@ -357,9 +348,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install pnpm
         run: npm install pnpm@latest-9 -g
@@ -479,9 +467,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install pnpm
         run: npm install pnpm@latest-9 -g


### PR DESCRIPTION
npm's latest major (12.x) turns the previously soft "Unknown cli config" warning for pnpm-only flags (--no-git-checks) into a hard EUNKNOWNCONFIG error, breaking every pnpm publish step. Since the workflow always installed whatever npm was "latest" at CI run time, this broke with no repo changes once npm 12 shipped. Removing the forced upgrade lets Node 24's bundled npm (11.x) stand, which still accepts the flag.