### PR TITLE
Regenerate V2 client for folder-path auto-create (import + entry creation)

### DIFF
--- a/packages/lf-repository-api-client-v2/generate-client/swagger.json
+++ b/packages/lf-repository-api-client-v2/generate-client/swagger.json
@@ -8,10 +8,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:11211/repository"
-    },
-    {
-      "url": "https://localhost:11211/repository"
+      "url": "https://api.laserfiche.com/repository"
     }
   ],
   "paths": {
@@ -4553,6 +4550,16 @@
             "x-position": 2
           },
           {
+            "name": "autoCreateFolderPath",
+            "in": "query",
+            "description": "When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 4
+          },
+          {
             "name": "culture",
             "in": "query",
             "description": "An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.",
@@ -4561,7 +4568,7 @@
               "default": "",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           }
         ],
         "requestBody": {
@@ -5461,6 +5468,16 @@
             "x-position": 2
           },
           {
+            "name": "autoCreateFolderPath",
+            "in": "query",
+            "description": "When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 3
+          },
+          {
             "name": "culture",
             "in": "query",
             "description": "An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.",
@@ -5469,7 +5486,7 @@
               "default": "",
               "nullable": true
             },
-            "x-position": 3
+            "x-position": 4
           }
         ],
         "requestBody": {
@@ -6131,6 +6148,16 @@
             "x-position": 2
           },
           {
+            "name": "autoCreateFolderPath",
+            "in": "query",
+            "description": "When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 4
+          },
+          {
             "name": "culture",
             "in": "query",
             "description": "An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag.",
@@ -6139,7 +6166,7 @@
               "default": "",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           }
         ],
         "requestBody": {
@@ -21529,6 +21556,11 @@
             "type": "string",
             "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
             "nullable": true
+          },
+          "folderPath": {
+            "type": "string",
+            "description": "An optional folder path, relative to the entry given in the route, that the document is imported into.\nBoth `/` and `\\` are accepted as separators. When any folder in this path does not exist, set the\n`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request\nfails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior).",
+            "nullable": true
           }
         }
       },
@@ -22481,6 +22513,11 @@
             "type": "boolean",
             "description": "Whether to generate searchable text (OCR) for image pages added via `imageFiles`. Default: true.\nDoes not affect pages generated from `file` \u2014 use `pdfOptions.generateText` for those.",
             "default": true
+          },
+          "folderPath": {
+            "type": "string",
+            "description": "An optional folder path, relative to the entry given in the route, that the document is imported into.\nBoth `/` and `\\` are accepted as separators. When any folder in this path does not exist, set the\n`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request\nfails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior).",
+            "nullable": true
           }
         }
       },
@@ -22960,6 +22997,11 @@
           "volumeName": {
             "type": "string",
             "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
+            "nullable": true
+          },
+          "folderPath": {
+            "type": "string",
+            "description": "An optional folder path, relative to the entry given in the route, that the new entry is created under.\nBoth `/` and `\\` are accepted as separators. When any folder in this path does not exist, set the\n`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request\nfails with 404. When omitted, the entry is created directly under the route entry (unchanged behavior).",
             "nullable": true
           }
         }

--- a/packages/lf-repository-api-client-v2/index.ts
+++ b/packages/lf-repository-api-client-v2/index.ts
@@ -156,7 +156,7 @@ export class AnnotationsClient implements IAnnotationsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -1471,7 +1471,7 @@ export class AttributesClient implements IAttributesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -1785,7 +1785,7 @@ export class AuditReasonsClient implements IAuditReasonsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -2066,7 +2066,7 @@ export class FieldDefinitionsClient implements IFieldDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -3584,7 +3584,7 @@ export class AccessControlClient implements IAccessControlClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -5107,7 +5107,7 @@ export class LinkDefinitionsClient implements ILinkDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -5420,10 +5420,11 @@ export interface IEntriesClient {
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry ID of the folder that the document will be created in.
      * @param args.request (optional) The request body.
+     * @param args.autoCreateFolderPath (optional) When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @returns Operation was started successfully. Returned a long operation task ID.
      */
-    startImportUploadedParts(args: { repositoryId: string, entryId: number, request?: StartImportUploadedPartsRequest | undefined, culture?: string | null | undefined }): Promise<StartTaskResponse>;
+    startImportUploadedParts(args: { repositoryId: string, entryId: number, request?: StartImportUploadedPartsRequest | undefined, autoCreateFolderPath?: boolean | undefined, culture?: string | null | undefined }): Promise<StartTaskResponse>;
 
     /**
      * - Starts an asynchronous export operation to export an entry.
@@ -5507,13 +5508,14 @@ export interface IEntriesClient {
     - Required OAuth scope: repository.Write
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry ID of the folder that the document will be created in.
+     * @param args.autoCreateFolderPath (optional) When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @param args.file (optional) Optional. The file to import. If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if importAsElectronicDocument=true, it is stored as the electronic document. Otherwise (image extension with importAsElectronicDocument=false), it is imported as image pages. A zero-byte file creates an empty document with no electronic document and no pages.
      * @param args.request (optional) 
      * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Document was created successfully. Returns created entry.
      */
-    importEntry(args: { repositoryId: string, entryId: number, culture?: string | null | undefined, file?: FileParameter | undefined, request?: ImportEntryRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry>;
+    importEntry(args: { repositoryId: string, entryId: number, autoCreateFolderPath?: boolean | undefined, culture?: string | null | undefined, file?: FileParameter | undefined, request?: ImportEntryRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry>;
 
     /**
      * - Export an entry.
@@ -5569,10 +5571,11 @@ export interface IEntriesClient {
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The folder ID that the entry will be created in.
      * @param args.request The request body.
+     * @param args.autoCreateFolderPath (optional) When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag.
      * @returns Document was created successfully. Returns created entry.
      */
-    createEntry(args: { repositoryId: string, entryId: number, request: CreateEntryRequest, culture?: string | null | undefined }): Promise<Entry>;
+    createEntry(args: { repositoryId: string, entryId: number, request: CreateEntryRequest, autoCreateFolderPath?: boolean | undefined, culture?: string | null | undefined }): Promise<Entry>;
 
     /**
      * - Returns the fields assigned to an entry.
@@ -6001,7 +6004,7 @@ export class EntriesClient implements IEntriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -6440,11 +6443,12 @@ export class EntriesClient implements IEntriesClient {
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry ID of the folder that the document will be created in.
      * @param args.request (optional) The request body.
+     * @param args.autoCreateFolderPath (optional) When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @returns Operation was started successfully. Returned a long operation task ID.
      */
-    startImportUploadedParts(args: { repositoryId: string, entryId: number, request?: StartImportUploadedPartsRequest | undefined, culture?: string | null | undefined }): Promise<StartTaskResponse> {
-        let { repositoryId, entryId, request, culture } = args;
+    startImportUploadedParts(args: { repositoryId: string, entryId: number, request?: StartImportUploadedPartsRequest | undefined, autoCreateFolderPath?: boolean | undefined, culture?: string | null | undefined }): Promise<StartTaskResponse> {
+        let { repositoryId, entryId, request, autoCreateFolderPath, culture } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Folder/ImportUploadedParts?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -6452,6 +6456,10 @@ export class EntriesClient implements IEntriesClient {
         if (entryId === undefined || entryId === null)
             throw new Error("The parameter 'entryId' must be defined.");
         url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (autoCreateFolderPath === null)
+            throw new Error("The parameter 'autoCreateFolderPath' cannot be null.");
+        else if (autoCreateFolderPath !== undefined)
+            url_ += "autoCreateFolderPath=" + encodeURIComponent("" + autoCreateFolderPath) + "&";
         if (culture !== undefined && culture !== null)
             url_ += "culture=" + encodeURIComponent("" + culture) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -7100,14 +7108,15 @@ export class EntriesClient implements IEntriesClient {
     - Required OAuth scope: repository.Write
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The entry ID of the folder that the document will be created in.
+     * @param args.autoCreateFolderPath (optional) When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
      * @param args.file (optional) Optional. The file to import. If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if importAsElectronicDocument=true, it is stored as the electronic document. Otherwise (image extension with importAsElectronicDocument=false), it is imported as image pages. A zero-byte file creates an empty document with no electronic document and no pages.
      * @param args.request (optional) 
      * @param args.imageFiles (optional) Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
      * @returns Document was created successfully. Returns created entry.
      */
-    importEntry(args: { repositoryId: string, entryId: number, culture?: string | null | undefined, file?: FileParameter | undefined, request?: ImportEntryRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry> {
-        let { repositoryId, entryId, culture, file, request, imageFiles } = args;
+    importEntry(args: { repositoryId: string, entryId: number, autoCreateFolderPath?: boolean | undefined, culture?: string | null | undefined, file?: FileParameter | undefined, request?: ImportEntryRequest | undefined, imageFiles?: FileParameter[] | undefined }): Promise<Entry> {
+        let { repositoryId, entryId, autoCreateFolderPath, culture, file, request, imageFiles } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Folder/Import?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -7115,6 +7124,10 @@ export class EntriesClient implements IEntriesClient {
         if (entryId === undefined || entryId === null)
             throw new Error("The parameter 'entryId' must be defined.");
         url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (autoCreateFolderPath === null)
+            throw new Error("The parameter 'autoCreateFolderPath' cannot be null.");
+        else if (autoCreateFolderPath !== undefined)
+            url_ += "autoCreateFolderPath=" + encodeURIComponent("" + autoCreateFolderPath) + "&";
         if (culture !== undefined && culture !== null)
             url_ += "culture=" + encodeURIComponent("" + culture) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -7562,11 +7575,12 @@ export class EntriesClient implements IEntriesClient {
      * @param args.repositoryId The requested repository ID.
      * @param args.entryId The folder ID that the entry will be created in.
      * @param args.request The request body.
+     * @param args.autoCreateFolderPath (optional) When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
      * @param args.culture (optional) An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag.
      * @returns Document was created successfully. Returns created entry.
      */
-    createEntry(args: { repositoryId: string, entryId: number, request: CreateEntryRequest, culture?: string | null | undefined }): Promise<Entry> {
-        let { repositoryId, entryId, request, culture } = args;
+    createEntry(args: { repositoryId: string, entryId: number, request: CreateEntryRequest, autoCreateFolderPath?: boolean | undefined, culture?: string | null | undefined }): Promise<Entry> {
+        let { repositoryId, entryId, request, autoCreateFolderPath, culture } = args;
         let url_ = this.baseUrl + "/v2/Repositories/{repositoryId}/Entries/{entryId}/Folder/Children?";
         if (repositoryId === undefined || repositoryId === null)
             throw new Error("The parameter 'repositoryId' must be defined.");
@@ -7574,6 +7588,10 @@ export class EntriesClient implements IEntriesClient {
         if (entryId === undefined || entryId === null)
             throw new Error("The parameter 'entryId' must be defined.");
         url_ = url_.replace("{entryId}", encodeURIComponent("" + entryId));
+        if (autoCreateFolderPath === null)
+            throw new Error("The parameter 'autoCreateFolderPath' cannot be null.");
+        else if (autoCreateFolderPath !== undefined)
+            url_ += "autoCreateFolderPath=" + encodeURIComponent("" + autoCreateFolderPath) + "&";
         if (culture !== undefined && culture !== null)
             url_ += "culture=" + encodeURIComponent("" + culture) + "&";
         url_ = url_.replace(/[?&]$/, "");
@@ -11109,7 +11127,7 @@ export class RecordsManagementClient implements IRecordsManagementClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -12042,7 +12060,7 @@ export class RepositoriesClient implements IRepositoriesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -12203,7 +12221,7 @@ export class SearchesClient implements ISearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -12777,7 +12795,7 @@ export class SimpleSearchesClient implements ISimpleSearchesClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -12980,7 +12998,7 @@ export class StampsClient implements IStampsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -13585,7 +13603,7 @@ export class TagDefinitionsClient implements ITagDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -13922,7 +13940,7 @@ export class TasksClient implements ITasksClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -14403,7 +14421,7 @@ export class TemplateDefinitionsClient implements ITemplateDefinitionsClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     
@@ -16240,7 +16258,7 @@ export class UserAreasClient implements IUserAreasClient {
 
     constructor(baseUrl?: string, http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> }) {
         this.http = http ? http : window as any;
-        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "http://localhost:11211/repository";
+        this.baseUrl = baseUrl !== undefined && baseUrl !== null ? baseUrl : "https://api.laserfiche.com/repository";
     }
 
     /**
@@ -21892,6 +21910,11 @@ For any other file type (PDF, Word, Excel, etc.), the file is always imported as
     metadata?: ImportEntryRequestMetadata | undefined;
     /** The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud. */
     volumeName?: string | undefined;
+    /** An optional folder path, relative to the entry given in the route, that the document is imported into.
+Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the
+`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request
+fails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior). */
+    folderPath?: string | undefined;
 
     
     
@@ -21923,6 +21946,7 @@ For any other file type (PDF, Word, Excel, etc.), the file is always imported as
             this.importAsElectronicDocument = _data["importAsElectronicDocument"] !== undefined ? _data["importAsElectronicDocument"] : false;
             this.metadata = _data["metadata"] ? ImportEntryRequestMetadata.fromJS(_data["metadata"]) : <any>undefined;
             this.volumeName = _data["volumeName"];
+            this.folderPath = _data["folderPath"];
         }
     }
 
@@ -21947,6 +21971,7 @@ For any other file type (PDF, Word, Excel, etc.), the file is always imported as
         data["importAsElectronicDocument"] = this.importAsElectronicDocument;
         data["metadata"] = this.metadata ? this.metadata.toJSON() : <any>undefined;
         data["volumeName"] = this.volumeName;
+        data["folderPath"] = this.folderPath;
         return data;
     }
 }
@@ -21971,6 +21996,11 @@ For any other file type (PDF, Word, Excel, etc.), the file is always imported as
     metadata?: ImportEntryRequestMetadata | undefined;
     /** The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud. */
     volumeName?: string | undefined;
+    /** An optional folder path, relative to the entry given in the route, that the document is imported into.
+Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the
+`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request
+fails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior). */
+    folderPath?: string | undefined;
 }
 
 /** Server-side processing options for the imported file. Despite the type name, these fields apply to any supported electronic document as well as to files imported as image pages. */
@@ -23356,6 +23386,11 @@ For any other file type (PDF, Word, Excel, etc.), the file is always imported as
     /** Whether to generate searchable text (OCR) for image pages added via `imageFiles`. Default: true.
 Does not affect pages generated from `file` — use `pdfOptions.generateText` for those. */
     generateImagePagesText?: boolean;
+    /** An optional folder path, relative to the entry given in the route, that the document is imported into.
+Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the
+`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request
+fails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior). */
+    folderPath?: string | undefined;
 
     
     
@@ -23382,6 +23417,7 @@ Does not affect pages generated from `file` — use `pdfOptions.generateText` fo
             this.metadata = _data["metadata"] ? ImportEntryRequestMetadata.fromJS(_data["metadata"]) : <any>undefined;
             this.volumeName = _data["volumeName"];
             this.generateImagePagesText = _data["generateImagePagesText"] !== undefined ? _data["generateImagePagesText"] : true;
+            this.folderPath = _data["folderPath"];
         }
     }
 
@@ -23401,6 +23437,7 @@ Does not affect pages generated from `file` — use `pdfOptions.generateText` fo
         data["metadata"] = this.metadata ? this.metadata.toJSON() : <any>undefined;
         data["volumeName"] = this.volumeName;
         data["generateImagePagesText"] = this.generateImagePagesText;
+        data["folderPath"] = this.folderPath;
         return data;
     }
 }
@@ -23424,6 +23461,11 @@ For any other file type (PDF, Word, Excel, etc.), the file is always imported as
     /** Whether to generate searchable text (OCR) for image pages added via `imageFiles`. Default: true.
 Does not affect pages generated from `file` — use `pdfOptions.generateText` for those. */
     generateImagePagesText?: boolean;
+    /** An optional folder path, relative to the entry given in the route, that the document is imported into.
+Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the
+`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request
+fails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior). */
+    folderPath?: string | undefined;
 }
 
 /** Response containing a link to download the exported entry. */
@@ -24385,6 +24427,11 @@ export class CreateEntryRequest implements ICreateEntryRequest {
     targetId?: number;
     /** The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud. */
     volumeName?: string | undefined;
+    /** An optional folder path, relative to the entry given in the route, that the new entry is created under.
+Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the
+`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request
+fails with 404. When omitted, the entry is created directly under the route entry (unchanged behavior). */
+    folderPath?: string | undefined;
 
     
     
@@ -24407,6 +24454,7 @@ export class CreateEntryRequest implements ICreateEntryRequest {
             this.entryType = _data["entryType"];
             this.targetId = _data["targetId"];
             this.volumeName = _data["volumeName"];
+            this.folderPath = _data["folderPath"];
         }
     }
 
@@ -24424,6 +24472,7 @@ export class CreateEntryRequest implements ICreateEntryRequest {
         data["entryType"] = this.entryType;
         data["targetId"] = this.targetId;
         data["volumeName"] = this.volumeName;
+        data["folderPath"] = this.folderPath;
         return data;
     }
 }
@@ -24440,6 +24489,11 @@ export interface ICreateEntryRequest {
     targetId?: number;
     /** The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud. */
     volumeName?: string | undefined;
+    /** An optional folder path, relative to the entry given in the route, that the new entry is created under.
+Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the
+`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request
+fails with 404. When omitted, the entry is created directly under the route entry (unchanged behavior). */
+    folderPath?: string | undefined;
 }
 
 /** Enumeration of entry types for CreateEntry. */

--- a/packages/lf-repository-api-client-v2/test/Entries/CreateEntryFolderPath.test.ts
+++ b/packages/lf-repository-api-client-v2/test/Entries/CreateEntryFolderPath.test.ts
@@ -1,0 +1,190 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId } from '../TestHelper.js';
+import { _RepositoryApiClient } from '../CreateSession.js';
+import {
+  CreateEntryRequest,
+  CreateEntryRequestEntryType,
+  Entry,
+  EntryType,
+  StartDeleteEntryRequest,
+} from '../../index.js';
+import { getDeleteEntryAuditReasonId } from '../BaseTest.js';
+
+// Integration tests for the recursive folder-path ("mkdir -p") feature on
+// POST /Folder/Children / createEntry (#687492): the optional `folderPath` request-body property
+// (relative to the route entry) plus the `autoCreateFolderPath` query flag, exercised through the
+// JS client. These validate that the JS client serializes the new JSON body property and appends
+// the query flag correctly, and that the OData route resolves — the class of routing/serialization
+// bug that has historically surfaced first in the JS client. createEntry uses no multipart upload,
+// so these run under both node and jsdom.
+describe('Create Entry - Folder Path', () => {
+  let rootId: number | undefined;
+
+  afterEach(async () => {
+    if (rootId) {
+      const request = new StartDeleteEntryRequest();
+      request.auditReasonId = await getDeleteEntryAuditReasonId(_RepositoryApiClient);
+      await _RepositoryApiClient.entriesClient.startDeleteEntry({ repositoryId, entryId: rootId, request });
+      rootId = undefined;
+    }
+  });
+
+  // Each test gets its own uniquely-named root folder directly under the repository root so tests
+  // never collide on shared fixture state (folder deletes in LFS are asynchronous). autoRename is
+  // off so the name is exact and path lookups are deterministic.
+  async function newRoot(): Promise<{ id: number; name: string }> {
+    const name = `APIServer_JS_CreateEntryFolderPath_${crypto.randomUUID().replace(/-/g, '')}`;
+    const request = new CreateEntryRequest();
+    request.entryType = CreateEntryRequestEntryType.Folder;
+    request.name = name;
+    request.autoRename = false;
+    const entry = await _RepositoryApiClient.entriesClient.createEntry({ repositoryId, entryId: 1, request });
+    rootId = entry.id!;
+    return { id: entry.id!, name };
+  }
+
+  async function createFolder(
+    entryId: number,
+    name: string,
+    folderPath: string | undefined,
+    autoCreateFolderPath: boolean | undefined,
+    autoRename = false
+  ): Promise<Entry> {
+    const request = new CreateEntryRequest();
+    request.entryType = CreateEntryRequestEntryType.Folder;
+    request.name = name;
+    request.autoRename = autoRename;
+    request.folderPath = folderPath;
+    return await _RepositoryApiClient.entriesClient.createEntry({ repositoryId, entryId, request, autoCreateFolderPath });
+  }
+
+  async function createShortcut(
+    entryId: number,
+    name: string,
+    targetId: number,
+    folderPath: string | undefined,
+    autoCreateFolderPath: boolean | undefined
+  ): Promise<Entry> {
+    const request = new CreateEntryRequest();
+    request.entryType = CreateEntryRequestEntryType.Shortcut;
+    request.name = name;
+    request.targetId = targetId;
+    request.folderPath = folderPath;
+    return await _RepositoryApiClient.entriesClient.createEntry({ repositoryId, entryId, request, autoCreateFolderPath });
+  }
+
+  async function makeFolder(parentId: number, name: string): Promise<Entry> {
+    const request = new CreateEntryRequest();
+    request.entryType = CreateEntryRequestEntryType.Folder;
+    request.name = name;
+    return await _RepositoryApiClient.entriesClient.createEntry({ repositoryId, entryId: parentId, request });
+  }
+
+  // GetEntryByPath uses backslash separators; normalize the forward-slash paths built for readability.
+  async function getByPath(fullPath: string): Promise<Entry> {
+    const response = await _RepositoryApiClient.entriesClient.getEntryByPath({
+      repositoryId,
+      fullPath: fullPath.replace(/\//g, '\\'),
+    });
+    return response.entry!;
+  }
+
+  async function pathExists(fullPath: string): Promise<boolean> {
+    try {
+      await getByPath(fullPath);
+      return true;
+    } catch (e: any) {
+      if (e.status === 404) return false;
+      throw e;
+    }
+  }
+
+  test('folder, all-new path, autoCreate=true creates the path and the leaf', async () => {
+    const root = await newRoot();
+
+    const result = await createFolder(root.id, 'Leaf', 'A/B', true);
+
+    expect(result).not.toBeNull();
+    expect(await pathExists(`${root.name}/A`)).toBe(true);
+    const pathLeaf = await getByPath(`${root.name}/A/B`);
+    // The created folder sits under the resolved path leaf.
+    expect(result.parentId).toBe(pathLeaf.id);
+    expect(result.entryType).toBe(EntryType.Folder);
+    expect(await pathExists(`${root.name}/A/B/Leaf`)).toBe(true);
+  });
+
+  test('folder, missing path, no flag returns 404 and creates nothing', async () => {
+    const root = await newRoot();
+
+    let threw = false;
+    let status: number | undefined;
+    try {
+      await createFolder(root.id, 'Leaf', 'X/Y', false);
+    } catch (e: any) {
+      threw = true;
+      status = e.status;
+    }
+    expect(threw).toBe(true);
+    expect(status).toBe(404);
+    expect(await pathExists(`${root.name}/X`)).toBe(false);
+  });
+
+  test('folder, mixed existing and new, autoCreate reuses existing and creates missing', async () => {
+    const root = await newRoot();
+    const existingA = await makeFolder(root.id, 'A');
+
+    const result = await createFolder(root.id, 'Leaf', 'A/B', true);
+
+    // A reused (same id), B created.
+    expect((await getByPath(`${root.name}/A`)).id).toBe(existingA.id);
+    const pathLeaf = await getByPath(`${root.name}/A/B`);
+    expect(result.parentId).toBe(pathLeaf.id);
+  });
+
+  test('shortcut with folderPath, autoCreate creates the shortcut under the resolved leaf', async () => {
+    const root = await newRoot();
+
+    // The shortcut target is the root folder itself; the shortcut lands under an auto-made path.
+    const result = await createShortcut(root.id, 'Sc', root.id, 'A/B', true);
+
+    expect(result).not.toBeNull();
+    expect(result.entryType).toBe(EntryType.Shortcut);
+    const pathLeaf = await getByPath(`${root.name}/A/B`);
+    expect(result.parentId).toBe(pathLeaf.id);
+    expect(await pathExists(`${root.name}/A/B/Sc`)).toBe(true);
+  });
+
+  test('no folderPath is backwards compatible (created directly under the anchor)', async () => {
+    const root = await newRoot();
+
+    const result = await createFolder(root.id, 'Leaf', undefined, undefined);
+
+    expect(result).not.toBeNull();
+    expect(result.parentId).toBe(root.id);
+  });
+
+  test.each(['A/B', 'A\\B'])('forward and backslash separators are equivalent (%s)', async (folderPath) => {
+    const root = await newRoot();
+
+    const result = await createFolder(root.id, 'Leaf', folderPath, true);
+
+    const leaf = await getByPath(`${root.name}/A/B`);
+    expect(result.parentId).toBe(leaf.id);
+  });
+
+  test.each(['A/../B', 'A//B'])('invalid path segment (%s) returns 400', async (folderPath) => {
+    const root = await newRoot();
+
+    let threw = false;
+    let status: number | undefined;
+    try {
+      await createFolder(root.id, 'Leaf', folderPath, true);
+    } catch (e: any) {
+      threw = true;
+      status = e.status;
+    }
+    expect(threw).toBe(true);
+    expect(status).toBe(400);
+  });
+});

--- a/packages/lf-repository-api-client-v2/test/Entries/ImportFolderPath.test.ts
+++ b/packages/lf-repository-api-client-v2/test/Entries/ImportFolderPath.test.ts
@@ -1,0 +1,142 @@
+// Copyright Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+import { repositoryId } from '../TestHelper.js';
+import { _RepositoryApiClient } from '../CreateSession.js';
+import {
+  CreateEntryRequest,
+  CreateEntryRequestEntryType,
+  Entry,
+  FileParameter,
+  ImportEntryRequest,
+  StartDeleteEntryRequest,
+} from '../../index.js';
+import { getDeleteEntryAuditReasonId, SKIP_UNDER_JSDOM } from '../BaseTest.js';
+
+// Integration tests for the recursive folder-path ("mkdir -p") feature on
+// POST /Folder/Import / importEntry (#687491): the optional `folderPath` request-body property
+// (relative to the route entry) plus the `autoCreateFolderPath` query flag, exercised through the
+// JS client. importEntry sends a Blob in a multipart body, so the whole suite is gated with
+// SKIP_UNDER_JSDOM (vitest+jsdom multipart-fetch hang, TFS #658052) and runs under node only.
+// These validate that the JS client threads `folderPath` through the multipart form and appends
+// the query flag correctly on the OData route.
+describe.skipIf(SKIP_UNDER_JSDOM)('Import Entry - Folder Path', () => {
+  let rootId: number | undefined;
+
+  afterEach(async () => {
+    if (rootId) {
+      const request = new StartDeleteEntryRequest();
+      request.auditReasonId = await getDeleteEntryAuditReasonId(_RepositoryApiClient);
+      await _RepositoryApiClient.entriesClient.startDeleteEntry({ repositoryId, entryId: rootId, request });
+      rootId = undefined;
+    }
+  });
+
+  async function newRoot(): Promise<{ id: number; name: string }> {
+    const name = `APIServer_JS_ImportFolderPath_${crypto.randomUUID().replace(/-/g, '')}`;
+    const request = new CreateEntryRequest();
+    request.entryType = CreateEntryRequestEntryType.Folder;
+    request.name = name;
+    request.autoRename = false;
+    const entry = await _RepositoryApiClient.entriesClient.createEntry({ repositoryId, entryId: 1, request });
+    rootId = entry.id!;
+    return { id: entry.id!, name };
+  }
+
+  async function makeFolder(parentId: number, name: string): Promise<Entry> {
+    const request = new CreateEntryRequest();
+    request.entryType = CreateEntryRequestEntryType.Folder;
+    request.name = name;
+    return await _RepositoryApiClient.entriesClient.createEntry({ repositoryId, entryId: parentId, request });
+  }
+
+  async function importDoc(
+    entryId: number,
+    name: string,
+    autoRename: boolean,
+    folderPath: string | undefined,
+    autoCreateFolderPath: boolean | undefined
+  ): Promise<Entry> {
+    const blob = new Blob(['integration test content'], { type: 'application/pdf' });
+    const request = new ImportEntryRequest();
+    request.name = name;
+    request.autoRename = autoRename;
+    request.folderPath = folderPath;
+    const edoc: FileParameter = { fileName: 'test.pdf', data: blob };
+    return await _RepositoryApiClient.entriesClient.importEntry({
+      repositoryId,
+      entryId,
+      file: edoc,
+      request,
+      autoCreateFolderPath,
+    });
+  }
+
+  // GetEntryByPath uses backslash separators; normalize the forward-slash paths built for readability.
+  async function getByPath(fullPath: string): Promise<Entry> {
+    const response = await _RepositoryApiClient.entriesClient.getEntryByPath({
+      repositoryId,
+      fullPath: fullPath.replace(/\//g, '\\'),
+    });
+    return response.entry!;
+  }
+
+  async function pathExists(fullPath: string): Promise<boolean> {
+    try {
+      await getByPath(fullPath);
+      return true;
+    } catch (e: any) {
+      if (e.status === 404) return false;
+      throw e;
+    }
+  }
+
+  test('all-new path, autoCreate=true creates the path and imports into the leaf', async () => {
+    const root = await newRoot();
+
+    const result = await importDoc(root.id, 'mkdirp_doc', true, 'A/B/C', true);
+
+    expect(result).not.toBeNull();
+    expect(result.id!).toBeGreaterThan(0);
+    expect(await pathExists(`${root.name}/A`)).toBe(true);
+    expect(await pathExists(`${root.name}/A/B`)).toBe(true);
+    const leaf = await getByPath(`${root.name}/A/B/C`);
+    expect(result.parentId).toBe(leaf.id);
+  });
+
+  test('missing path, no flag returns 404 and creates nothing', async () => {
+    const root = await newRoot();
+
+    let threw = false;
+    let status: number | undefined;
+    try {
+      await importDoc(root.id, 'noflag_doc', true, 'X/Y', false);
+    } catch (e: any) {
+      threw = true;
+      status = e.status;
+    }
+    expect(threw).toBe(true);
+    expect(status).toBe(404);
+    expect(await pathExists(`${root.name}/X`)).toBe(false);
+  });
+
+  test('existing path, no flag imports into the leaf', async () => {
+    const root = await newRoot();
+    const existingA = await makeFolder(root.id, 'A');
+    const existingB = await makeFolder(existingA.id, 'B');
+
+    // Flag off, but the whole path already exists → import succeeds into the leaf.
+    const result = await importDoc(root.id, 'existing_doc', true, 'A/B', false);
+
+    expect(result).not.toBeNull();
+    expect(result.parentId).toBe(existingB.id);
+  });
+
+  test('no folderPath is backwards compatible (imported directly into the anchor)', async () => {
+    const root = await newRoot();
+
+    const result = await importDoc(root.id, 'compat_doc', true, undefined, undefined);
+
+    expect(result).not.toBeNull();
+    expect(result.parentId).toBe(root.id);
+  });
+});


### PR DESCRIPTION
Regenerates the V2 JS client for the folder-path auto-create surface added server-side under epic #687490 (stories #687491 import, #687492 entry creation; server PR merged).

## Surface added
- New optional `folderPath` body property on `CreateEntryRequest`, `ImportEntryRequest`, and `StartImportUploadedPartsRequest`.
- New `autoCreateFolderPath` query parameter on `createEntry`, `importEntry`, and `startImportUploadedParts`.

When `folderPath` is omitted, behavior is byte-for-byte unchanged (backwards compatible within v2). `autoCreateFolderPath` (default `false`) gates creation of missing path segments.

## Changes
- Regenerated `swagger.json` + `index.ts` (localhost baseUrl/`servers` normalized back to prod).
- Two new integration tests: `CreateEntryFolderPath.test.ts`, `ImportFolderPath.test.ts`.

Client code + tests only. The version bump / npm publish is handled as a separate final release step after the server work ships.

Work item #691369