### PR TITLE
Release 1.4.0: bump versions and changelog for folder-path auto-create

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ on:
 
 env:
   NPM_API_CLIENT_V1_VERSION: '1.1.12'
-  NPM_API_CLIENT_V2_VERSION: '1.3.0'
+  NPM_API_CLIENT_V2_VERSION: '1.4.0'
   NPM_CLIENT_CORE_VERSION: '1.1.21'
   NPM_JS_UTILS_VERSION: '4.0.15'
-  NPM_API_JS_CLIENT_VERSION: '1.3.0'
+  NPM_API_JS_CLIENT_VERSION: '1.4.0'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/packages/lf-api-js/CHANGELOG.md
+++ b/packages/lf-api-js/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!--Copyright Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
+## 1.4.0
+
+### Features
+
+- Updated version of `lf-repository-api-client-v2` to `1.4.0`:
+  - Add optional `folderPath` request property and `autoCreateFolderPath` query parameter to `createEntry`, `importEntry`, and `startImportUploadedParts`. When `autoCreateFolderPath` is `true`, any missing folders in `folderPath` are created; when `false` (default), a missing folder returns 404.
+
 ## 1.3.0
 
 ### Features

--- a/packages/lf-repository-api-client-v2/CHANGELOG.md
+++ b/packages/lf-repository-api-client-v2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.0
+
+### Features
+
+- Add optional `folderPath` request property and `autoCreateFolderPath` query parameter to `createEntry`, `importEntry`, and `startImportUploadedParts`. When `autoCreateFolderPath` is `true`, any missing folders in `folderPath` are created; when `false` (default), a missing folder returns 404.
+
 ## 1.3.0
 
 ### Features


### PR DESCRIPTION
Bumps lf-repository-api-client-v2 and lf-api-js to 1.4.0 for the folderPath/autoCreateFolderPath support on createEntry, importEntry, and startImportUploadedParts (Epic #687490).