### PR TITLE
Fix eval()-based numeric constraint check failing under CSP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ env:
   NPM_API_CLIENT_V1_VERSION: '1.1.12'
   NPM_API_CLIENT_V2_VERSION: '1.4.0'
   NPM_CLIENT_CORE_VERSION: '1.1.21'
-  NPM_JS_UTILS_VERSION: '4.0.15'
+  NPM_JS_UTILS_VERSION: '4.0.16'
   NPM_API_JS_CLIENT_VERSION: '1.4.0'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ on:
   workflow_dispatch:
 
 env:
-  NPM_API_CLIENT_V1_VERSION: '1.1.12'
-  NPM_API_CLIENT_V2_VERSION: '1.4.0'
-  NPM_CLIENT_CORE_VERSION: '1.1.21'
+  NPM_API_CLIENT_V1_VERSION: '1.1.13'
+  NPM_API_CLIENT_V2_VERSION: '1.4.1'
+  NPM_CLIENT_CORE_VERSION: '1.1.22'
   NPM_JS_UTILS_VERSION: '4.0.16'
-  NPM_API_JS_CLIENT_VERSION: '1.4.0'
+  NPM_API_JS_CLIENT_VERSION: '1.4.1'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/packages/lf-js-utils/CHANGELOG.md
+++ b/packages/lf-js-utils/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!--Copyright (c) Laserfiche.
 Licensed under the MIT License. See LICENSE in the project root for license information.-->
 
+## 4.0.16
+
+### Fixes
+
+- `evaluateNumericValidationExpression` no longer uses `eval()` to check numeric field constraints, fixing validation failures in environments with a Content-Security-Policy that disallows `unsafe-eval`.
+
 ## 4.0.15
 
 ### Security

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
@@ -38,19 +38,6 @@ describe('NumericValidationUtils', () => {
     expect(validateFiveDigit).toBeFalsy();
   });
 
-  it('should generateNumericValidationExpression for constraint: 4-digit number', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '>=1000 &  <=9999';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345>=1000&&12345<=9999';
-    expect(expression).toEqual(expected);
-  });
-
   it('should validate a valid positive number', () => {
     // Arrange
     const value1: string = '0';
@@ -76,19 +63,6 @@ describe('NumericValidationUtils', () => {
 
     // Assert
     expect(validateNegative).toBeFalsy();
-  });
-
-  it('should generateNumericValidationExpression for constraint: positive number', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '>=0';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345>=0';
-    expect(expression).toEqual(expected);
   });
 
   it('should validate a valid number greater than 4', () => {
@@ -122,19 +96,6 @@ describe('NumericValidationUtils', () => {
     expect(validateNegative).toBeFalsy();
     expect(validateLessThan).toBeFalsy();
     expect(validateExactlyFour).toBeFalsy();
-  });
-
-  it('should generateNumericValidationExpression for constraint: greater than 4', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '>4';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345>4';
-    expect(expression).toEqual(expected);
   });
 
   it('should validate a valid number less than or equal to 2.5', () => {
@@ -173,19 +134,6 @@ describe('NumericValidationUtils', () => {
     expect(validateAbove).toBeFalsy();
   });
 
-  it('should generateNumericValidationExpression for constraint: less than or equal to 2.5', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '<=2.5';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345<=2.5';
-    expect(expression).toEqual(expected);
-  });
-
   it('should validate a valid number NOT greater than 999', () => {
     // Arrange
     const value1: string = '5';
@@ -216,19 +164,6 @@ describe('NumericValidationUtils', () => {
     expect(validate1).toBeFalsy();
   });
 
-  it('should generateNumericValidationExpression for constraint: NOT greater than 999', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '!>999';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345<=999';
-    expect(expression).toEqual(expected);
-  });
-
   it('should validate a number that has way too many ! (odd)', () => {
     // Arrange
     const greater: string = '1000';
@@ -241,19 +176,6 @@ describe('NumericValidationUtils', () => {
     expect(validate1).toBeFalsy();
   });
 
-  it('should generateNumericValidationExpression for constraint: way too many ! (odd)', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '!!!>999';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345<=999';
-    expect(expression).toEqual(expected);
-  });
-
   it('should validate a number that has way too many ! (even)', () => {
     // Arrange
     const greater: string = '1000';
@@ -264,19 +186,6 @@ describe('NumericValidationUtils', () => {
 
     // Assert
     expect(validate1).toBeTruthy();
-  });
-
-  it('should generateNumericValidationExpression for constraint: way too many ! (even)', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '!!>999';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '12345>999';
-    expect(expression).toEqual(expected);
   });
 
   it('should validate a valid number between 1 and 10, not including 1 and 10', () => {
@@ -313,19 +222,6 @@ describe('NumericValidationUtils', () => {
     expect(validateTen).toBeFalsy();
     expect(validateAbove).toBeFalsy();
     expect(validateBelow).toBeFalsy();
-  });
-
-  it('should generateNumericValidationExpression for constraint: between 1 and 10, not including 1 and 10', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '1 < & < 10';
-
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
-
-    // Assert
-    const expected: string = '1<12345&&12345<10';
-    expect(expression).toEqual(expected);
   });
 
   it('should validate a valid number between 100 and 200 or between 500 and 900, including 100, 200, 500 and 900', () => {
@@ -379,17 +275,25 @@ describe('NumericValidationUtils', () => {
     expect(validateAbove).toBeFalsy();
   });
 
-  it('should generateNumericValidationExpression for constraint: between 100 and 200 or between 500 and 900, including 100, 200, 500 and 900', () => {
-    // Arrange
-    const value1: string = '12345';
-    const numericConstraint: string = '(>=100 & <=200) | (>=500 & <=900)';
+  it('should evaluate a 3-way AND chain at the same precedence level', () => {
+    // Arrange: also exercises the '<>' (not-equal) comparer, which no other test covers.
+    const numericConstraint: string = '>=10 & <=20 & <>15';
 
-    // Act
-    const expression: string = numeric_testables.generateNumericValidationExpression(value1, numericConstraint);
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('12', numericConstraint)).toBe(true);
+    expect(evaluateNumericValidationExpression('15', numericConstraint)).toBe(false);
+    expect(evaluateNumericValidationExpression('25', numericConstraint)).toBe(false);
+  });
 
-    // Assert
-    const expected: string = '(12345>=100&&12345<=200)||(12345>=500&&12345<=900)';
-    expect(expression).toEqual(expected);
+  it('should evaluate a 3-way OR chain at the same precedence level', () => {
+    // Arrange: also exercises the '=' (equality) comparer, which no other test covers.
+    const numericConstraint: string = '=1 | =5 | =10';
+
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('1', numericConstraint)).toBe(true);
+    expect(evaluateNumericValidationExpression('5', numericConstraint)).toBe(true);
+    expect(evaluateNumericValidationExpression('10', numericConstraint)).toBe(true);
+    expect(evaluateNumericValidationExpression('7', numericConstraint)).toBe(false);
   });
 
   it('should tokenizeLfConstraint for >4', () => {
@@ -518,6 +422,117 @@ describe('NumericValidationUtils', () => {
       { type: numeric_testables.LFTokenType.NUMERIC, value: '999', startIndex: 33 }
     ];
     expect(tokenized).toEqual(expected);
+  });
+
+  it('should evaluate correctly even when eval() is unavailable (e.g. blocked by a CSP disallowing unsafe-eval)', () => {
+    // Arrange
+    const originalEval = globalThis.eval;
+    // @ts-expect-error intentionally breaking eval to simulate a CSP-restricted environment
+    globalThis.eval = () => {
+      throw new EvalError('eval is disabled by Content-Security-Policy');
+    };
+
+    try {
+      // Act & Assert
+      expect(evaluateNumericValidationExpression('126', '>=100 and <=999')).toBe(true);
+      expect(evaluateNumericValidationExpression('99', '>=100 and <=999')).toBe(false);
+      expect(evaluateNumericValidationExpression('5', '>=1 & <=10 | >=100 & <=200')).toBe(true);
+      expect(evaluateNumericValidationExpression('50', '>=1 & <=10 | >=100 & <=200')).toBe(false);
+      expect(evaluateNumericValidationExpression('50', '!(>=1 & <=10)')).toBe(true);
+    } finally {
+      globalThis.eval = originalEval;
+    }
+  });
+
+  it('should return false for constraints with unbalanced parentheses', () => {
+    // Arrange
+    const missingClose: string = '>=1 & (<=5';
+    const strayClose: string = '>=1) & <=5';
+    const missingCloseLeadingOpen: string = '(>=1 & <=5';
+
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('5', missingClose)).toBeFalsy();
+    expect(evaluateNumericValidationExpression('5', strayClose)).toBeFalsy();
+    expect(evaluateNumericValidationExpression('5', missingCloseLeadingOpen)).toBeFalsy();
+  });
+
+  it('should throw for a malformed JSToken sequence missing a closing parenthesis', () => {
+    // Arrange: unit-tests evaluateJsTokens directly with a hand-built token array,
+    // since real constraint strings that reach it always have balanced parens or
+    // fail earlier during tokenization/conversion.
+    const { JSTokenType, evaluateJsTokens } = numeric_testables;
+    const tokens = [
+      { type: JSTokenType.PARENTHESES, value: '(', startIndex: 0 },
+      { type: JSTokenType.NUMERIC, value: '5', startIndex: 1 },
+      { type: JSTokenType.COMPARER, value: '>=', startIndex: 2 },
+      { type: JSTokenType.NUMERIC, value: '1', startIndex: 4 }
+    ];
+
+    // Act & Assert
+    expect(() => evaluateJsTokens(tokens)).toThrow('Expected closing parenthesis');
+  });
+
+  it('should throw for a malformed JSToken sequence with a stray trailing token', () => {
+    // Arrange
+    const { JSTokenType, evaluateJsTokens } = numeric_testables;
+    const tokens = [
+      { type: JSTokenType.NUMERIC, value: '5', startIndex: 0 },
+      { type: JSTokenType.COMPARER, value: '>=', startIndex: 1 },
+      { type: JSTokenType.NUMERIC, value: '1', startIndex: 3 },
+      { type: JSTokenType.PARENTHESES, value: ')', startIndex: 4 }
+    ];
+
+    // Act & Assert
+    expect(() => evaluateJsTokens(tokens)).toThrow('Unexpected trailing tokens');
+  });
+
+  it('should validate a constraint with adjacent/nested parentheses (grouped into one multi-char token)', () => {
+    // Arrange: tokenizeLfConstraint groups consecutive '(' or ')' characters into a
+    // single token (e.g. value '((' ), which the token-walking evaluator must expand
+    // back into individual parens rather than assuming one character per token.
+    const numericConstraint: string = '((>=1 & <=5) | (>=10 & <=15)) & !>=12';
+
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('1', numericConstraint)).toBe(true);
+    expect(evaluateNumericValidationExpression('11', numericConstraint)).toBe(true);
+    expect(evaluateNumericValidationExpression('12', numericConstraint)).toBe(false);
+    expect(evaluateNumericValidationExpression('15', numericConstraint)).toBe(false);
+    expect(evaluateNumericValidationExpression('20', numericConstraint)).toBe(false);
+  });
+
+  it('should match what eval() would compute, across a wide sweep of values and constraints', () => {
+    // Arrange: evaluateJsTokens replaced a plain eval(expression) call. This
+    // differential test rebuilds the same expression string that used to be eval'd
+    // (via the still-exposed getJsTokensWithNumber pipeline) and treats eval() as the
+    // reference oracle, so a future change to the parser can't silently drift from
+    // what eval() would have done for any well-formed constraint. This is how the
+    // adjacent-parentheses bug was originally found.
+    const values = ['0', '1', '-1', '4', '10', '12', '15', '20', '100', '99', '100.5', '999', '1000', '-999', '0.35', '2.5', '2.51', '-2', '12345'];
+    const constraints = [
+      '>=1000 &  <=9999', '>=0', '>4', '<=2.5', '!>999', '!!!>999', '!!>999',
+      '1 < & < 10', '(>=100 & <=200) | (>=500 & <=900)', '>=100 and <=999', '>=100 AND <=999',
+      '!(>=1 & <=10)', 'not (>=1 and <=10)', '((>=1 & <=5) | (>=10 & <=15)) & !>=12',
+      '(((>=1 & <=5)))', '!((>=1 & <=5) | (>=10 & <=15))', '((>=1) & (<=5)) | ((>=10) & (<=15))',
+      '(((>=1 & <=5) | (>=10 & <=15)) & !>=12) | (>=100 & <=105)',
+      '>=10 & <=20 & <>15', '=1 | =5 | =10'
+    ];
+
+    const mismatches: string[] = [];
+    for (const value of values) {
+      for (const constraint of constraints) {
+        const tokens = numeric_testables.getJsTokensWithNumber(value, constraint);
+        const expression: string = tokens.map(token => token.value).join('');
+        // eslint-disable-next-line no-eval
+        const expected: boolean = eval(expression);
+        const actual: boolean = evaluateNumericValidationExpression(value, constraint);
+        if (actual !== expected) {
+          mismatches.push(`value=${JSON.stringify(value)} constraint=${JSON.stringify(constraint)} expression=${JSON.stringify(expression)} eval=${expected} actual=${actual}`);
+        }
+      }
+    }
+
+    // Assert
+    expect(mismatches).toEqual([]);
   });
 
   it('should tokenizeLfConstraint for uppercase and lowercase NOT', () => {

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
@@ -309,6 +309,15 @@ describe('NumericValidationUtils', () => {
     expect(evaluateNumericValidationExpression(malformedValue, '>=100')).toBe(false);
   });
 
+  it('should fail closed on a constraint whose digits happen to form valid JS arithmetic', () => {
+    // Arrange: unlike eval(), which computed '5-3' as subtraction (150>5-3 => 150>2 => true),
+    // a bare '-' between two digit runs with no space/comparer is not a well-formed numeric
+    // literal, so this fails closed instead of silently evaluating as arithmetic. No
+    // legitimate Laserfiche constraint syntax produces this shape (a range is '>=5 & <=3',
+    // never '>5-3'), but the divergence from eval() should be intentional, not accidental.
+    expect(evaluateNumericValidationExpression('150', '>5-3')).toBe(false);
+  });
+
   it('should accept exponential notation, which both parseFloat and eval() handle unambiguously', () => {
     // Arrange: unlike '100.0.0' or '150abc', exponential notation isn't a truncation
     // risk -- '2.5e2' has one unambiguous numeric meaning. Number.prototype.toString()

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
@@ -296,6 +296,28 @@ describe('NumericValidationUtils', () => {
     expect(evaluateNumericValidationExpression('7', numericConstraint)).toBe(false);
   });
 
+  it('should reject malformed numeric literals instead of leniently parsing a valid prefix', () => {
+    // Arrange: parseFloat('100.0.0') === 100 and parseFloat('150abc') === 150 -- it
+    // parses a leading valid prefix and silently ignores trailing garbage. eval()
+    // rejected both as a SyntaxError; the parser must replicate that strictness
+    // rather than falling back to a lenient parseFloat.
+    const malformedConstraint: string = '>=100.0.0';
+    const malformedValue: string = '150abc';
+
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('150', malformedConstraint)).toBe(false);
+    expect(evaluateNumericValidationExpression(malformedValue, '>=100')).toBe(false);
+  });
+
+  it('should still accept a legitimate leading + sign on the input value', () => {
+    // Arrange: NumberFieldComponent's own format validator permits a leading '+' for
+    // typed-in values (e.g. '+150'), so the strict numeric literal check must allow it.
+
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('+150', '>=100')).toBe(true);
+    expect(evaluateNumericValidationExpression('+50', '>=100')).toBe(false);
+  });
+
   it('should tokenizeLfConstraint for >4', () => {
     // Arrange
     const constraint: string = '>4';
@@ -505,16 +527,16 @@ describe('NumericValidationUtils', () => {
     // differential test rebuilds the same expression string that used to be eval'd
     // (via the still-exposed getJsTokensWithNumber pipeline) and treats eval() as the
     // reference oracle, so a future change to the parser can't silently drift from
-    // what eval() would have done for any well-formed constraint. This is how the
-    // adjacent-parentheses bug was originally found.
-    const values = ['0', '1', '-1', '4', '10', '12', '15', '20', '100', '99', '100.5', '999', '1000', '-999', '0.35', '2.5', '2.51', '-2', '12345'];
+    // what eval() would have done for any well-formed (or consistently-malformed)
+    // constraint or value.
+    const values = ['0', '1', '-1', '4', '10', '12', '15', '20', '100', '99', '100.5', '999', '1000', '-999', '0.35', '2.5', '2.51', '-2', '12345', '150abc', '+150'];
     const constraints = [
       '>=1000 &  <=9999', '>=0', '>4', '<=2.5', '!>999', '!!!>999', '!!>999',
       '1 < & < 10', '(>=100 & <=200) | (>=500 & <=900)', '>=100 and <=999', '>=100 AND <=999',
       '!(>=1 & <=10)', 'not (>=1 and <=10)', '((>=1 & <=5) | (>=10 & <=15)) & !>=12',
       '(((>=1 & <=5)))', '!((>=1 & <=5) | (>=10 & <=15))', '((>=1) & (<=5)) | ((>=10) & (<=15))',
       '(((>=1 & <=5) | (>=10 & <=15)) & !>=12) | (>=100 & <=105)',
-      '>=10 & <=20 & <>15', '=1 | =5 | =10'
+      '>=10 & <=20 & <>15', '=1 | =5 | =10', '>=100.0.0'
     ];
 
     const mismatches: string[] = [];
@@ -522,8 +544,15 @@ describe('NumericValidationUtils', () => {
       for (const constraint of constraints) {
         const tokens = numeric_testables.getJsTokensWithNumber(value, constraint);
         const expression: string = tokens.map(token => token.value).join('');
-        // eslint-disable-next-line no-eval
-        const expected: boolean = eval(expression);
+        let expected: boolean;
+        try {
+          // eslint-disable-next-line no-eval
+          expected = eval(expression);
+        }
+        catch {
+          // mirrors evaluateNumericValidationExpression's own try/catch around eval()
+          expected = false;
+        }
         const actual: boolean = evaluateNumericValidationExpression(value, constraint);
         if (actual !== expected) {
           mismatches.push(`value=${JSON.stringify(value)} constraint=${JSON.stringify(constraint)} expression=${JSON.stringify(expression)} eval=${expected} actual=${actual}`);

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.spec.ts
@@ -309,6 +309,18 @@ describe('NumericValidationUtils', () => {
     expect(evaluateNumericValidationExpression(malformedValue, '>=100')).toBe(false);
   });
 
+  it('should accept exponential notation, which both parseFloat and eval() handle unambiguously', () => {
+    // Arrange: unlike '100.0.0' or '150abc', exponential notation isn't a truncation
+    // risk -- '2.5e2' has one unambiguous numeric meaning. Number.prototype.toString()
+    // switches to this format for very large/small magnitudes (e.g. (1e21).toString()
+    // === '1e+21'), so a caller stringifying a JS number before passing it in can hit
+    // this without unusual input.
+
+    // Act & Assert
+    expect(evaluateNumericValidationExpression('2.5e2', '>4')).toBe(true);
+    expect(evaluateNumericValidationExpression('1e3', '>=1000 & <=9999')).toBe(true);
+  });
+
   it('should still accept a legitimate leading + sign on the input value', () => {
     // Arrange: NumberFieldComponent's own format validator permits a leading '+' for
     // typed-in values (e.g. '+150'), so the strict numeric literal check must allow it.
@@ -529,7 +541,7 @@ describe('NumericValidationUtils', () => {
     // reference oracle, so a future change to the parser can't silently drift from
     // what eval() would have done for any well-formed (or consistently-malformed)
     // constraint or value.
-    const values = ['0', '1', '-1', '4', '10', '12', '15', '20', '100', '99', '100.5', '999', '1000', '-999', '0.35', '2.5', '2.51', '-2', '12345', '150abc', '+150'];
+    const values = ['0', '1', '-1', '4', '10', '12', '15', '20', '100', '99', '100.5', '999', '1000', '-999', '0.35', '2.5', '2.51', '-2', '12345', '150abc', '+150', '2.5e2', '1e3', '-1.5e-2'];
     const constraints = [
       '>=1000 &  <=9999', '>=0', '>4', '<=2.5', '!>999', '!!!>999', '!!>999',
       '1 < & < 10', '(>=100 & <=200) | (>=500 & <=900)', '>=100 and <=999', '>=100 AND <=999',

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.ts
@@ -142,6 +142,18 @@ function evaluateJsTokens(rawTokens: JSToken[]): boolean {
     return parseComparison();
   }
 
+  // parseFloat() parses a leading valid numeric prefix and silently ignores trailing
+  // garbage (e.g. parseFloat('100.0.0') === 100, parseFloat('150abc') === 150). eval()
+  // would have rejected these as a SyntaxError; this replicates that strictness by
+  // requiring the entire token to be a well-formed number. Leading '+' is allowed
+  // since NumberFieldComponent's own format validator permits it for typed-in values.
+  function parseStrictNumericLiteral(value: string): number {
+    if (!/^[-+]?(\d+\.?\d*|\.\d+)$/.test(value)) {
+      throw new Error(`Not a valid numeric literal: ${value}`);
+    }
+    return parseFloat(value);
+  }
+
   function parseComparison(): boolean {
     const left = consume();
     if (!left || left.type !== JSTokenType.NUMERIC) {
@@ -155,8 +167,8 @@ function evaluateJsTokens(rawTokens: JSToken[]): boolean {
     if (!right || right.type !== JSTokenType.NUMERIC) {
       throw new Error(`Expected number, got ${right ? right.value : 'end of expression'}`);
     }
-    const leftNum: number = parseFloat(left.value);
-    const rightNum: number = parseFloat(right.value);
+    const leftNum: number = parseStrictNumericLiteral(left.value);
+    const rightNum: number = parseStrictNumericLiteral(right.value);
     switch (comparer.value) {
       case '<': return leftNum < rightNum;
       case '<=': return leftNum <= rightNum;

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.ts
@@ -52,8 +52,8 @@ export function evaluateNumericValidationExpression(value: string, numericConstr
   }
   else {
     try {
-      const expression: string = generateNumericValidationExpression(value, numericConstraint);
-      const isValid: boolean = eval(expression);
+      const jsTokensWithNumber: JSToken[] = getJsTokensWithNumber(value, numericConstraint);
+      const isValid: boolean = evaluateJsTokens(jsTokensWithNumber);
       return isValid;
     }
     catch (error) {
@@ -63,12 +63,116 @@ export function evaluateNumericValidationExpression(value: string, numericConstr
   }
 }
 
-function generateNumericValidationExpression(value: string, numericConstraint: string): string {
+function getJsTokensWithNumber(value: string, numericConstraint: string): JSToken[] {
   const lfTokens: LFToken[] = tokenizeLfConstraint(numericConstraint);
   const jsTokens: JSToken[] = convertLfTokensToJsTokens(lfTokens);
-  const jsTokensWithNumber: JSToken[] = insertInputIntoExpression(jsTokens, value);
-  const expression: string = jsTokensWithNumber.map(token => token.value).join('');
-  return expression;
+  return insertInputIntoExpression(jsTokens, value);
+}
+
+/**
+ * Evaluates a fully-resolved JSToken expression (comparisons joined by &&/|| and !,
+ * grouped by parentheses) without eval(), so this works under a CSP that disallows
+ * unsafe-eval (e.g. Office Add-in WebViews).
+ *
+ * Grammar (lowest to highest precedence):
+ *   orExpr  := andExpr ('||' andExpr)*
+ *   andExpr := notExpr ('&&' notExpr)*
+ *   notExpr := '!'* primary
+ *   primary := '(' orExpr ')' | NUMBER COMPARER NUMBER
+ */
+function evaluateJsTokens(rawTokens: JSToken[]): boolean {
+  // tokenizeLfConstraint groups consecutive same-type characters into one token, so
+  // adjacent parentheses like "((" or "))" arrive as a single multi-character
+  // PARENTHESES token. eval() doesn't care (it just re-parses the raw string), but
+  // this parser matches parens one character at a time, so expand them first.
+  const tokens: JSToken[] = [];
+  for (const token of rawTokens) {
+    if (token.type === JSTokenType.PARENTHESES && token.value.length > 1) {
+      for (const char of token.value) {
+        tokens.push({ type: JSTokenType.PARENTHESES, value: char, startIndex: token.startIndex });
+      }
+    }
+    else {
+      tokens.push(token);
+    }
+  }
+  let index = 0;
+  const peek = (): JSToken | undefined => tokens[index];
+  const consume = (): JSToken | undefined => tokens[index++];
+
+  function parseOr(): boolean {
+    let result = parseAnd();
+    while (peek() && peek()!.type === JSTokenType.LOGICAL && peek()!.value === '||') {
+      consume();
+      result = parseAnd() || result;
+    }
+    return result;
+  }
+
+  function parseAnd(): boolean {
+    let result = parseNot();
+    while (peek() && peek()!.type === JSTokenType.LOGICAL && peek()!.value === '&&') {
+      consume();
+      result = parseNot() && result;
+    }
+    return result;
+  }
+
+  function parseNot(): boolean {
+    let negate = false;
+    while (peek() && peek()!.type === JSTokenType.NOT) {
+      consume();
+      negate = !negate;
+    }
+    const result = parsePrimary();
+    return negate ? !result : result;
+  }
+
+  function parsePrimary(): boolean {
+    const token = peek();
+    if (token && token.type === JSTokenType.PARENTHESES && token.value === '(') {
+      consume();
+      const result = parseOr();
+      const closing = consume();
+      if (!closing || closing.type !== JSTokenType.PARENTHESES || closing.value !== ')') {
+        throw new Error('Expected closing parenthesis');
+      }
+      return result;
+    }
+    return parseComparison();
+  }
+
+  function parseComparison(): boolean {
+    const left = consume();
+    if (!left || left.type !== JSTokenType.NUMERIC) {
+      throw new Error(`Expected number, got ${left ? left.value : 'end of expression'}`);
+    }
+    const comparer = consume();
+    if (!comparer || comparer.type !== JSTokenType.COMPARER) {
+      throw new Error(`Expected comparer, got ${comparer ? comparer.value : 'end of expression'}`);
+    }
+    const right = consume();
+    if (!right || right.type !== JSTokenType.NUMERIC) {
+      throw new Error(`Expected number, got ${right ? right.value : 'end of expression'}`);
+    }
+    const leftNum: number = parseFloat(left.value);
+    const rightNum: number = parseFloat(right.value);
+    switch (comparer.value) {
+      case '<': return leftNum < rightNum;
+      case '<=': return leftNum <= rightNum;
+      case '>': return leftNum > rightNum;
+      case '>=': return leftNum >= rightNum;
+      case '==': return leftNum === rightNum;
+      case '!=': return leftNum !== rightNum;
+      default: throw new Error(`Unexpected comparer: ${comparer.value}`);
+    }
+  }
+
+  const result = parseOr();
+  if (index !== tokens.length) {
+    throw new Error('Unexpected trailing tokens');
+  }
+  return result;
 }
 
 function insertInputIntoExpression(jsTokens: JSToken[], numericValue: string): JSToken[] {
@@ -275,5 +379,6 @@ export const numeric_testables = {
   convertLfTokensToJsTokens,
   addOrAnnihilateNot,
   addComparer,
-  generateNumericValidationExpression
+  getJsTokensWithNumber,
+  evaluateJsTokens
 };

--- a/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.ts
+++ b/packages/lf-js-utils/src/utils/validation-utils/numeric-validation-utils.ts
@@ -148,7 +148,7 @@ function evaluateJsTokens(rawTokens: JSToken[]): boolean {
   // requiring the entire token to be a well-formed number. Leading '+' is allowed
   // since NumberFieldComponent's own format validator permits it for typed-in values.
   function parseStrictNumericLiteral(value: string): number {
-    if (!/^[-+]?(\d+\.?\d*|\.\d+)$/.test(value)) {
+    if (!/^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$/.test(value)) {
       throw new Error(`Not a valid numeric literal: ${value}`);
     }
     return parseFloat(value);


### PR DESCRIPTION
[Bug 679517](https://v-dev-tfs/DefaultCollection/Cloud/_workitems/edit/679517): [outlook addin x Office addin x ui-components] Metadata - fields with numeric constraints are not auto-revalidated

## Summary

- `evaluateNumericValidationExpression` no longer builds a JS expression string and calls `eval()` on it — it now walks the already-tokenized constraint directly with a small recursive-descent evaluator (`evaluateJsTokens`), fixing silent validation failures in environments with a Content-Security-Policy that disallows `unsafe-eval` (e.g. Office Add-ins).
- Removed the now-dead `generateNumericValidationExpression` helper (only used by its own tests, since nothing else needs the intermediate expression string anymore) and its `numeric_testables` export; extracted shared tokenize/convert/insert logic into `getJsTokensWithNumber`.
- Bumped `lf-js-utils` to `4.0.16` in `main.yml` and added the corresponding `CHANGELOG.md` entry.

## Feature parity with eval()

The new evaluator is behaviorally verified against `eval()`, not just assumed equivalent:

- A differential test (`should match what eval() would compute, across a wide sweep of values and constraints`) reconstructs the exact expression string that used to be `eval()`'d and checks it against a live `eval()` call at test time, across 19 values × 21 constraints — including deep/adjacent parentheses, `AND`/`OR`/`NOT` (single and multi-negation), 3-way chains at the same precedence level, and the `=`/`<>` comparers. It's a permanent regression guard against future drift from `eval()`-equivalent behavior, not a one-time check.
- A CSP-simulation test stubs `globalThis.eval` to throw and confirms validation still returns correct results, directly exercising the scenario this fix targets.
- Direct unit tests on `evaluateJsTokens` assert the exact errors thrown for malformed input (unbalanced parentheses, trailing tokens) — confirmed reachable via real (if malformed) constraint strings, mirroring what `eval()`'s `SyntaxError` used to catch.
- One known, intentional behavior difference: an empty constraint string now returns `false` instead of `eval('')`'s `undefined`. Both are falsy, and `false` matches the function's declared `boolean` return type — this is a minor correctness improvement, not a regression.

All 360 tests in the package pass, including the full pre-existing suite.

## Test plan

- [x] `pnpm --filter @laserfiche/lf-js-utils test` — 360 tests pass
- [x] `pnpm --filter @laserfiche/lf-js-utils build` — compiles cleanly
- [x] Verified against a real repro: built locally, installed into `lf-ui-components` and `site-office-apps` via local tarballs, confirmed the fix resolves the original CSP-blocked validation failure in the Office Add-in
