### PR TITLE
fix(security): bump brace-expansion and fast-uri to remediate Veracode SCA flaws

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion": "^2.1.3",
+      "brace-expansion": "^2.1.4",
       "flat-cache": "^4.0.0",
       "flatted": "^3.4.0",
       "form-data": "4.0.6",
       "js-yaml": "4.3.0",
       "ajv": "^8.18.0",
-      "fast-uri": "^3.1.4",
+      "fast-uri": "^3.1.5",
       "glob": "^10.5.0",
       "linkify-it": "^5.0.2",
       "lodash": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: ^2.1.3
+  brace-expansion: ^2.1.4
   flat-cache: ^4.0.0
   flatted: ^3.4.0
   form-data: 4.0.6
   js-yaml: 4.3.0
   ajv: ^8.18.0
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   glob: ^10.5.0
   linkify-it: ^5.0.2
   lodash: ^4.18.1
@@ -972,8 +972,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  brace-expansion@2.1.3:
-    resolution: {integrity: sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1198,8 +1198,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
@@ -2829,7 +2829,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2861,7 +2861,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  brace-expansion@2.1.3:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -3089,7 +3089,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.19.0:
     dependencies:
@@ -3495,11 +3495,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.3
+      brace-expansion: 2.1.4
 
   minipass@7.1.3: {}
 


### PR DESCRIPTION
## Summary
- Bumps the `brace-expansion` pnpm override from `^2.1.3` to `^2.1.4`, backporting the fix for incomplete `maxLength` bounding. The comma-alternative accumulator and padded-sequence generation are now bounded before `combine()` runs, closing an out-of-memory / event-loop-stall DoS a crafted brace pattern could still trigger on 2.1.3.
- Bumps the `fast-uri` pnpm override from `^3.1.4` to `^3.1.5`, fixing a backslash authority-delimiter parsing desync vs Node's WHATWG URL where backslash-based delimiters were folded into the path instead of being treated as the host delimiter, letting host-based allow/deny checks be bypassed.
- Both stay within the major versions already required by `minimatch`/`ajv` (only devDependency consumers), so no consumer code changes were needed. Bumping `brace-expansion` straight to its 5.x latest was avoided deliberately: 5.x switched from a CJS default export to a named `expand` export, which breaks `minimatch`'s `require('brace-expansion')` usage.

## Test plan
- [x] `pnpm install` regenerates `pnpm-lock.yaml` with only the two target packages changed
- [x] `pnpm build` succeeds across all workspace packages
- [x] `pnpm --filter @laserfiche/lf-js-utils test` passes (368/368)
- [x] `pnpm generate-docs` (exercises `typedoc` -> `minimatch` -> `brace-expansion`) completes without error, confirming the CJS export shape still works

Generated with Claude Code